### PR TITLE
PR 2271- Setting 2 or more CCContacts in AR view produces a Traceback on Save

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ LIMS-1504: Calculation formula test widgets
 
 **Fixed**
 
-
+- #280 Integration of PR-2271.Setting 2 or more CCContacts in AR view produces a Traceback on Save
 **Security**
 
 

--- a/bika/lims/browser/header_table.py
+++ b/bika/lims/browser/header_table.py
@@ -34,9 +34,14 @@ class HeaderTableView(BrowserView):
             for field in fields:
                 fieldname = field.getName()
                 if fieldname in form:
-                    if fieldname + "_uid" in form:
-                        # references (process_form would normally do *_uid trick)
-                        field.getMutator(self.context)(form[fieldname + "_uid"])
+                    # Handle (multiValued) reference fields
+                    # https://github.com/bikalims/bika.lims/issues/2270
+                    uid_fieldname = "{}_uid".format(fieldname)
+                    if uid_fieldname in form:
+                        value = form[uid_fieldname]
+                        if field.multiValued:
+                            value = value.split(",")
+                        field.getMutator(self.context)(value)
                     else:
                         # other fields
                         field.getMutator(self.context)(form[fieldname])


### PR DESCRIPTION
Integration of https://github.com/bikalims/bika.lims/pull/2271

**Current behavior before PR**

Traceback occurs when setting 2 or more CCContacts in AR Table Header and clicking "Save"

**Desired behavior after PR is merged**

Values get stored accordingly