### PR TITLE
PR 2269 - Show the Unit in Manage Analyses View 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ LIMS-1504: Calculation formula test widgets
 **Fixed**
 
 - #280 Integration of PR-2271.Setting 2 or more CCContacts in AR view produces a Traceback on Save
+- #281 Integration of PR-2269. Show the Unit in Manage Analyses View
 **Security**
 
 

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -56,6 +56,11 @@ class AnalysisRequestAnalysesView(BikaListingView):
             'Title': {'title': _('Service'),
                       'index': 'title',
                       'sortable': False, },
+            'Unit': {
+                'title': _('Unit'),
+                'sortable': False,
+
+            },
             'Hidden': {'title': _('Hidden'),
                        'sortable': False,
                        'type': 'boolean', },
@@ -69,7 +74,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
             'error': {'title': _('Permitted Error %')},
         }
 
-        columns = ['Title', 'Hidden', ]
+        columns = ['Title', 'Unit', 'Hidden', ]
         ShowPrices = self.context.bika_setup.getShowPrices()
         if ShowPrices:
             columns.append('Price')
@@ -277,6 +282,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
             ser = self.context.getAnalysisServiceSettings(obj.UID())
             items[x]['allow_edit'].append('Hidden')
             items[x]['Hidden'] = ser.get('hidden', obj.getHidden())
-
+            items[x]['Unit'] = obj.getUnit()
         self.categories.sort()
         return items

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -64,17 +64,29 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 'sortable': False,
 
             },
-            'Hidden': {'title': _('Hidden'),
-                       'sortable': False,
-                       'type': 'boolean', },
-            'Price': {'title': _('Price'),
-                      'sortable': False, },
-            'Partition': {'title': _('Partition'),
-                          'sortable': False,
-                          'type': 'choices'},
-            'min': {'title': _('Min')},
-            'max': {'title': _('Max')},
-            'error': {'title': _('Permitted Error %')},
+            'Hidden': {
+                'title': _('Hidden'),
+                'sortable': False,
+                'type': 'boolean',
+            },
+            'Price': {
+                'title': _('Price'),
+                'sortable': False,
+            },
+            'Partition': {
+                'title': _('Partition'),
+                'sortable': False,
+                'type': 'choices'
+            },
+            'min': {
+                'title': _('Min')
+            },
+            'max': {
+                'title': _('Max')
+            },
+            'error': {
+                'title': _('Permitted Error %')
+            },
         }
 
         columns = ['Title', 'Unit', 'Hidden', ]
@@ -91,12 +103,13 @@ class AnalysisRequestAnalysesView(BikaListingView):
             columns.append('error')
 
         self.review_states = [
-            {'id': 'default',
-             'title': _('All'),
-             'contentFilter': {},
-             'columns': columns,
-             'transitions': [{'id': 'empty'}, ],  # none
-             'custom_actions': [{'id': 'save_analyses_button',
+            {
+                'id': 'default',
+                'title': _('All'),
+                'contentFilter': {},
+                'columns': columns,
+                'transitions': [{'id': 'empty'}, ],  # none
+                'custom_actions': [{'id': 'save_analyses_button',
                                  'title': _('Save')}, ],
              },
         ]
@@ -159,7 +172,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
         return json.dumps(rr_dict_by_service_uid)
 
     def get_spec_from_ar(self, ar, keyword):
-        empty = {'min': '', 'max': '', 'error': '', 'keyword':keyword}
+        empty = {'min': '', 'max': '', 'error': '', 'keyword': keyword}
         spec = ar.getResultsRange()
         if spec:
             return dicts_to_dict(spec, 'keyword').get(keyword, empty)

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -58,7 +58,8 @@ class AnalysisRequestAnalysesView(BikaListingView):
         self.columns = {
             'Title': {'title': _('Service'),
                       'index': 'title',
-                      'sortable': False, },
+                      'sortable': False,
+            },
             'Unit': {
                 'title': _('Unit'),
                 'sortable': False,
@@ -110,7 +111,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 'columns': columns,
                 'transitions': [{'id': 'empty'}, ],  # none
                 'custom_actions': [{'id': 'save_analyses_button',
-                                 'title': _('Save')}, ],
+                                    'title': _('Save')}, ],
              },
         ]
 
@@ -275,29 +276,29 @@ class AnalysisRequestAnalysesView(BikaListingView):
             after_icons = ''
             if obj.getAccredited():
                 after_icons += "<img\
-                        src='%s/++resource++bika.lims.images/accredited.png'\
-                        title='%s'>" % (
+                src='%s/++resource++bika.lims.images/accredited.png'\
+                title='%s'>" % (
                     self.portal_url,
                     t(_("Accredited"))
                 )
             if obj.getReportDryMatter():
                 after_icons += "<img\
-                        src='%s/++resource++bika.lims.images/dry.png'\
-                        title='%s'>" % (
+                src='%s/++resource++bika.lims.images/dry.png'\
+                title='%s'>" % (
                     self.portal_url,
                     t(_("Can be reported as dry matter"))
                 )
             if obj.getAttachmentOption() == 'r':
                 after_icons += "<img\
-                        src='%s/++resource++bika.lims.images/attach_reqd.png'\
-                        title='%s'>" % (
+                src='%s/++resource++bika.lims.images/attach_reqd.png'\
+                title='%s'>" % (
                     self.portal_url,
                     t(_("Attachment required"))
                 )
             if obj.getAttachmentOption() == 'n':
                 after_icons += "<img\
-                        src='%s/++resource++bika.lims.images/attach_no.png'\
-                        title='%s'>" % (
+                src='%s/++resource++bika.lims.images/attach_no.png'\
+                title='%s'>" % (
                     self.portal_url,
                     t(_('Attachment not permitted'))
                 )

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -156,20 +156,20 @@ class AnalysisRequestAnalysesView(BikaListingView):
         """Return the AR Specs sorted by Service UID, so that the JS can
         work easily with the values.
         """
-
+        bsc = self.bika_setup_catalog
         rr_dict_by_service_uid = {}
         rr = self.context.getResultsRange()
         for r in rr:
-            uid = r.get("uid", None)
-            if not uid:
-                # get the AS by keyword
-                keyword = r.get("keyword")
-                service = self.get_service_by_keyword(keyword, None)
-                if service is not None:
-                    uid = api.get_uid(service)
-            if uid:
-                rr_dict_by_service_uid[uid] = r
-
+            keyword = r['keyword']
+            try:
+                service_uid = bsc(portal_type='AnalysisService',
+                                  getKeyword=keyword)[0].UID
+                rr_dict_by_service_uid[service_uid] = r
+            except IndexError:
+                from bika.lims import logger
+                error = "No Analysis Service found for Keyword '%s'. " \
+                        "Related: LIMS-1614"
+                logger.exception(error, keyword)
         return json.dumps(rr_dict_by_service_uid)
 
     def get_spec_from_ar(self, ar, keyword):

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -246,7 +246,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
             item['before']['Price'] = symbol
             item['Price'] = obj.getPrice()
             item['class']['Price'] = 'nowrap'
-            item['Priority'] = ''
 
             if item['selected']:
                 item['allow_edit'] = ['Partition', 'min', 'max', 'error']
@@ -266,15 +265,12 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 item["min"] = spec.get("min", '')
                 item["max"] = spec.get("max", '')
                 item["error"] = spec.get("error", '')
-                # Add priority premium
                 item['Price'] = analysis.getPrice()
-                item['Priority'] = analysis.getPriority()
             else:
                 item['Partition'] = ''
                 item["min"] = ''
                 item["max"] = ''
                 item["error"] = ''
-                item["Priority"] = ''
 
             after_icons = ''
             if obj.getAccredited():

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -206,104 +206,100 @@ class AnalysisRequestAnalysesView(BikaListingView):
                        'ResultText': o.getId()}
                       for o in parts
                       if wf.getInfoFor(o, 'cancellation_state', '') == 'active']
-        for x in range(len(items)):
-            if not 'obj' in items[x]:
+
+        for item in items:
+            if 'obj' not in item:
                 continue
-            obj = items[x]['obj']
+            obj = item['obj']
 
             cat = obj.getCategoryTitle()
-            items[x]['category'] = cat
+            item['category'] = cat
             if cat not in self.categories:
                 self.categories.append(cat)
 
-            items[x]['selected'] = items[x]['uid'] in self.selected
-
-            items[x]['class']['Title'] = 'service_title'
+            item['selected'] = item['uid'] in self.selected
+            item['class']['Title'] = 'service_title'
 
             # js checks in row_data if an analysis may be removed.
             row_data = {}
-            # keyword = obj.getKeyword()
-            # if keyword in review_states.keys() \
-            #    and review_states[keyword] not in ['sample_due',
-            #                                       'to_be_sampled',
-            #                                       'to_be_preserved',
-            #                                       'sample_received',
-            #                                       ]:
-            #     row_data['disabled'] = True
-            items[x]['row_data'] = json.dumps(row_data)
+            item['row_data'] = json.dumps(row_data)
 
             calculation = obj.getCalculation()
-            items[x]['Calculation'] = calculation and calculation.Title()
+            item['Calculation'] = calculation and calculation.Title()
 
             locale = locales.getLocale('en')
             currency = self.context.bika_setup.getCurrency()
             symbol = locale.numbers.currencies[currency].symbol
-            items[x]['before']['Price'] = symbol
-            items[x]['Price'] = obj.getPrice()
-            items[x]['class']['Price'] = 'nowrap'
+            item['before']['Price'] = symbol
+            item['Price'] = obj.getPrice()
+            item['class']['Price'] = 'nowrap'
+            item['Priority'] = ''
 
-            if items[x]['selected']:
-                items[x]['allow_edit'] = ['Partition', 'min', 'max', 'error']
+            if item['selected']:
+                item['allow_edit'] = ['Partition', 'min', 'max', 'error']
                 if not logged_in_client(self.context):
-                    items[x]['allow_edit'].append('Price')
+                    item['allow_edit'].append('Price')
 
-            items[x]['required'].append('Partition')
-            items[x]['choices']['Partition'] = partitions
+            item['required'].append('Partition')
+            item['choices']['Partition'] = partitions
 
             if obj.UID() in self.analyses:
                 analysis = self.analyses[obj.UID()]
                 part = analysis.getSamplePartition()
                 part = part and part or obj
-                items[x]['Partition'] = part.Title()
+                item['Partition'] = part.Title()
                 spec = self.get_spec_from_ar(self.context,
-                                             analysis.getKeyword())
-                items[x]["min"] = spec.get("min",'')
-                items[x]["max"] = spec.get("max",'')
-                items[x]["error"] = spec.get("error",'')
-                items[x]['Price'] = analysis.getPrice()
+                                             analysis.getService().getKeyword())
+                item["min"] = spec.get("min", '')
+                item["max"] = spec.get("max", '')
+                item["error"] = spec.get("error", '')
+                # Add priority premium
+                item['Price'] = analysis.getPrice()
+                item['Priority'] = analysis.getPriority()
             else:
-                items[x]['Partition'] = ''
-                items[x]["min"] = ''
-                items[x]["max"] = ''
-                items[x]["error"] = ''
+                item['Partition'] = ''
+                item["min"] = ''
+                item["max"] = ''
+                item["error"] = ''
+                item["Priority"] = ''
 
             after_icons = ''
             if obj.getAccredited():
                 after_icons += "<img\
-                src='%s/++resource++bika.lims.images/accredited.png'\
-                title='%s'>" % (
+                        src='%s/++resource++bika.lims.images/accredited.png'\
+                        title='%s'>" % (
                     self.portal_url,
                     t(_("Accredited"))
                 )
             if obj.getReportDryMatter():
                 after_icons += "<img\
-                src='%s/++resource++bika.lims.images/dry.png'\
-                title='%s'>" % (
+                        src='%s/++resource++bika.lims.images/dry.png'\
+                        title='%s'>" % (
                     self.portal_url,
                     t(_("Can be reported as dry matter"))
                 )
             if obj.getAttachmentOption() == 'r':
                 after_icons += "<img\
-                src='%s/++resource++bika.lims.images/attach_reqd.png'\
-                title='%s'>" % (
+                        src='%s/++resource++bika.lims.images/attach_reqd.png'\
+                        title='%s'>" % (
                     self.portal_url,
                     t(_("Attachment required"))
                 )
             if obj.getAttachmentOption() == 'n':
                 after_icons += "<img\
-                src='%s/++resource++bika.lims.images/attach_no.png'\
-                title='%s'>" % (
+                        src='%s/++resource++bika.lims.images/attach_no.png'\
+                        title='%s'>" % (
                     self.portal_url,
                     t(_('Attachment not permitted'))
                 )
             if after_icons:
-                items[x]['after']['Title'] = after_icons
-
+                item['after']['Title'] = after_icons
 
             # Display analyses for this Analysis Service in results?
             ser = self.context.getAnalysisServiceSettings(obj.UID())
-            items[x]['allow_edit'].append('Hidden')
-            items[x]['Hidden'] = ser.get('hidden', obj.getHidden())
-            items[x]['Unit'] = obj.getUnit()
+            item['allow_edit'] = ['Hidden', ]
+            item['Hidden'] = ser.get('hidden', obj.getHidden())
+            item['Unit'] = obj.getUnit()
+
         self.categories.sort()
         return items

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -261,7 +261,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 part = part and part or obj
                 item['Partition'] = part.Title()
                 spec = self.get_spec_from_ar(self.context,
-                                             analysis.getService().getKeyword())
+                                             analysis.getKeyword())
                 item["min"] = spec.get("min", '')
                 item["max"] = spec.get("max", '')
                 item["error"] = spec.get("error", '')


### PR DESCRIPTION
Linked issue: https://github.com/bikalims/bika.lims/issues/2268

### Behavior before PR

* Unit is not displayed in the "Manage Analyses" view

### Desired behavior after PR is merged

* Unit column is displayed per default

### Comments

I just noticed that on the Analysis Requests view the Priority column has no header text (see image attached). I think it might be better to name it for clarity. 

![screenshot from 2017-10-24 10-54-19](https://user-images.githubusercontent.com/9968427/31933607-e31e902c-b8a9-11e7-9cb6-d025ed29d53d.png)


 
