### PR TITLE
PR 2266 BikaListing. Instrument calibration table fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 ------------------
 
 **Added**
+merging PR 2266 from bikalims/bika.lims
+    fixed Issue-2263: Bika Listing: Clicking on the sorting-header of Instrument Calibrations re-renders the entire page recursively
+    fixed Issue-2264: Bika Listing: Instrument Calibration Table only shows 30 Items w/o pagination controls
 
 Issue-1999: Allow external Python library functions to be used in Calculation Formulas
 LIMS-1504: Calculation formula test widgets

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,10 @@ Changelog
 1.1.0 (Unreleased)
 ------------------
 
-**Added**
-merging PR 2266 from bikalims/bika.lims
-    fixed Issue-2263: Bika Listing: Clicking on the sorting-header of Instrument Calibrations re-renders the entire page recursively
-    fixed Issue-2264: Bika Listing: Instrument Calibration Table only shows 30 Items w/o pagination controls
+**Merged PRs from upstream**
+#282 Instrument Calibration Table fixes (pr #2266, Issues #2263 & #2264)
+
+**Changed**
 
 Issue-1999: Allow external Python library functions to be used in Calculation Formulas
 LIMS-1504: Calculation formula test widgets

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -501,40 +501,6 @@ class InstrumentReferenceAnalysesView(AnalysesView):
         return json.dumps(self.anjson)
 
 
-class InstrumentCertificationsViewView(BrowserView):
-    """ View of Instrument Certifications
-        Shows the list of Instrument Certifications, either Internal and
-        External Calibrations.
-    """
-
-    implements(IViewView)
-    template = ViewPageTemplateFile("templates/instrument_certifications.pt")
-    _certificationsview = None
-
-    def __call__(self):
-        view = self.get_certifications_view()
-        view._process_request()
-        if self.request.get('table_only', '') == view.form_id:
-            return view.contents_table()
-        elif self.request.get('rows_only', '') == view.form_id:
-            return view.contents_table()
-        else:
-            return self.template()
-
-    def get_certifications_table(self):
-        """ Returns the table of Certifications
-        """
-        return self.get_certifications_view().contents_table()
-
-    def get_certifications_view(self):
-        """ Returns the Certifications Table view
-        """
-        if not self._certificationsview:
-            self._certificationsview = InstrumentCertificationsView(
-                                        self.context,
-                                        self.request)
-        return self._certificationsview
-
 
 class InstrumentCertificationsView(BikaListingView):
     """ View for the table of Certifications. Includes Internal and

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -3,36 +3,29 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from Products.CMFPlone.utils import safe_unicode
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.browser.resultsimport.autoimportlogs import AutoImportLogsView
-from bika.lims.content.instrumentmaintenancetask import InstrumentMaintenanceTaskStatuses as mstatus
-from bika.lims.subscribers import doActionFor, skip
+import json
 from operator import itemgetter
-from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.layout.globals.interfaces import IViewView
-from plone.app.layout.viewlets import ViewletBase
-from zope.interface import implements
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.config import QCANALYSIS_TYPES
-from bika.lims.utils import to_utf8
-from bika.lims.permissions import *
-from operator import itemgetter
-from bika.lims.browser import BrowserView
-from bika.lims.browser.analyses import AnalysesView
-from bika.lims.browser.multifile import MultifileView
-from bika.lims.browser.analyses import QCAnalysesView
+
+import plone
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import bikaMessageFactory as _
+from bika.lims.browser import BrowserView
+from bika.lims.browser.analyses import AnalysesView
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.browser.multifile import MultifileView
+from bika.lims.browser.resultsimport.autoimportlogs import AutoImportLogsView
+from bika.lims.config import QCANALYSIS_TYPES
+from bika.lims.content.instrumentmaintenancetask import \
+    InstrumentMaintenanceTaskStatuses as mstatus
+from bika.lims.utils import t
+from plone.app.content.browser.interfaces import IFolderContentsView
+from plone.app.layout.globals.interfaces import IViewView
+from plone.app.layout.viewlets import ViewletBase
 from zExceptions import Forbidden
-from operator import itemgetter
-from bika.lims.catalog import CATALOG_AUTOIMPORTLOGS_LISTING
+from zope.interface import implements
 
-import plone
-import json
 
 class InstrumentMaintenanceView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -510,19 +503,18 @@ class InstrumentCertificationsView(BikaListingView):
         BikaListingView.__init__(self, context, request, **kwargs)
         self.form_id = "instrumentcertifications"
         self.columns = {
-            'Title': {'title': _('Cert. Num'),
-                      'index': 'sortable_title'},
-            'getAgency': {'title': _('Agency')},
-            'getDate': {'title': _('Date')},
-            'getValidFrom': {'title': _('Valid from')},
-            'getValidTo': {'title': _('Valid to')},
-            'getDocument': {'title': _('Document')},
+            'Title': {'title': _('Cert. Num'), 'index': 'sortable_title'},
+            'getAgency': {'title': _('Agency'), 'sortable': False},
+            'getDate': {'title': _('Date'), 'sortable': False},
+            'getValidFrom': {'title': _('Valid from'), 'sortable': False},
+            'getValidTo': {'title': _('Valid to'), 'sortable': False},
+            'getDocument': {'title': _('Document'), 'sortable': False},
         }
         self.review_states = [
             {'id':'default',
              'title':_('All'),
              'contentFilter':{},
-             'columns': [ 'Title',
+             'columns': ['Title',
                          'getAgency',
                          'getDate',
                          'getValidFrom',
@@ -539,10 +531,10 @@ class InstrumentCertificationsView(BikaListingView):
 
     def folderitems(self):
         items = BikaListingView.folderitems(self)
-        valid  = [c.UID() for c in self.context.getValidCertifications()]
+        valid = [c.UID() for c in self.context.getValidCertifications()]
         latest = self.context.getLatestValidCertification()
         latest = latest.UID() if latest else ''
-        for x in range (len(items)):
+        for x in range(len(items)):
             if not items[x].has_key('obj'): continue
             obj = items[x]['obj']
            # items[x]['getAgency'] = obj.getAgency()

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -512,7 +512,14 @@ class InstrumentCertificationsViewView(BrowserView):
     _certificationsview = None
 
     def __call__(self):
-        return self.template()
+        view = self.get_certifications_view()
+        view._process_request()
+        if self.request.get('table_only', '') == view.form_id:
+            return view.contents_table()
+        elif self.request.get('rows_only', '') == view.form_id:
+            return view.contents_table()
+        else:
+            return self.template()
 
     def get_certifications_table(self):
         """ Returns the table of Certifications
@@ -560,7 +567,7 @@ class InstrumentCertificationsView(BikaListingView):
         ]
         self.allow_edit = False
         self.show_select_column = False
-        self.show_workflow_action_buttons = False
+        self.show_workflow_action_buttons = True
         uids = [c.UID() for c in self.context.getCertifications()]
         self.catalog = 'portal_catalog'
         self.contentFilter = {'UID': uids, 'sort_on': 'sortable_title'}

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -501,7 +501,6 @@ class InstrumentReferenceAnalysesView(AnalysesView):
         return json.dumps(self.anjson)
 
 
-
 class InstrumentCertificationsView(BikaListingView):
     """ View for the table of Certifications. Includes Internal and
         External Calibrations. Also a bar to filter the results
@@ -529,7 +528,7 @@ class InstrumentCertificationsView(BikaListingView):
                          'getValidFrom',
                          'getValidTo',
                          'getDocument'],
-             'transitions': [{}]},
+             'transitions': []},
         ]
         self.allow_edit = False
         self.show_select_column = False

--- a/bika/lims/browser/instrument.zcml
+++ b/bika/lims/browser/instrument.zcml
@@ -15,7 +15,7 @@
     <browser:page
       for="bika.lims.interfaces.IInstrument"
       name="certifications"
-      class="bika.lims.browser.instrument.InstrumentCertificationsViewView"
+      class="bika.lims.browser.instrument.InstrumentCertificationsView"
       permission="zope.Public"
       layer="bika.lims.interfaces.IBikaLIMS"
     />

--- a/bika/lims/browser/templates/bika_listing_table.pt
+++ b/bika/lims/browser/templates/bika_listing_table.pt
@@ -250,7 +250,6 @@ Colum Headers
 Workflow Actions
 ********************************</tal:comment>
         <td class="workflow_actions">
-            <?python import pdb;pdb.set_trace(); ?>
             <input type="hidden" id="restricted_transitions"
                 tal:condition="view/bika_listing/show_workflow_action_buttons"
                 tal:attributes="value python:','.join([trans['id'] for trans in view.bika_listing.review_state.get('transitions', [])])"/>

--- a/bika/lims/browser/templates/bika_listing_table.pt
+++ b/bika/lims/browser/templates/bika_listing_table.pt
@@ -250,6 +250,7 @@ Colum Headers
 Workflow Actions
 ********************************</tal:comment>
         <td class="workflow_actions">
+            <?python import pdb;pdb.set_trace(); ?>
             <input type="hidden" id="restricted_transitions"
                 tal:condition="view/bika_listing/show_workflow_action_buttons"
                 tal:attributes="value python:','.join([trans['id'] for trans in view.bika_listing.review_state.get('transitions', [])])"/>

--- a/bika/lims/browser/templates/instrument_certifications.pt
+++ b/bika/lims/browser/templates/instrument_certifications.pt
@@ -48,11 +48,10 @@
     </metal:content-description>
 
     <metal:content-core fill-slot="content-core">
-    <!-- Certifications table -->
-    <tal:certificatestable>
-    <tal:parts replace="structure view/get_certifications_table"/>
-    </tal:certificatestable>
-
+        <!-- Certifications table -->
+        <tal:certificatestable>
+            <tal:parts replace="structure view/contents_table"/>
+        </tal:certificatestable>
     </metal:content-core>
 </body>
 </html>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Original PR: https://github.com/bikalims/bika.lims/pull/2266

Linked issues:
- https://github.com/bikalims/bika.lims/issues/2263
- https://github.com/bikalims/bika.lims/issues/2264

## Current behavior before PR

- Calibration table breaks if the user clicks on the sorting header
- Calibration table has no paging controls and shows only 30 Items

## Desired behavior after PR is merged

Calibration listing table works as expected
