### PR TITLE
PR 1972- Landscape Layout for Reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Issue-1999: Allow external Python library functions to be used in Calculation Fo
 LIMS-1504: Calculation formula test widgets
 #2154: Feature/new ar add form
 
+- #291 Integration of PR-1972. Landscape Layout for Reports
+
 **Fixed**
 
 - #280 Integration of PR-2271.Setting 2 or more CCContacts in AR view produces a Traceback on Save

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -261,6 +261,11 @@ class AnalysisRequestPublishView(BrowserView):
         """
         return self.request.form.get('hvisible', '0').lower() in ['true', '1']
 
+    def isLandscape(self):
+        """ Returns if the layout is landscape
+        """
+        return self.request.form.get('landscape', '0').lower() in ['true', '1']
+
     def localise_images(self, htmlreport):
         """WeasyPrint will attempt to retrieve attachments directly from the URL
         referenced in the HTML report, which may refer back to a single-threaded

--- a/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
+++ b/bika/lims/browser/analysisrequest/templates/analysisrequest_publish.pt
@@ -50,6 +50,7 @@
                     left: <input class='option-margin' id="margin-left" type="text"/>
                 </div>
                 <div class='options-line'>
+                    <input type="checkbox" name="landscape" id='landscape' value="0"><span i18n:translate="">Landscape</span><br/>
                     <input type="checkbox" name="qcvisible" id='qcvisible' value="0"><span i18n:translate="">Show QC Analyses</span><br/>
                     <input type="checkbox" name="hvisible" id='hvisible' value="0"><span i18n:translate="">Show Hidden Analyses</span>
                 </div>


### PR DESCRIPTION
Integration of https://github.com/bikalims/bika.lims/pull/1972 which was actually partly included by @rockfruit with https://github.com/senaite/bika.lims/commit/acfbb32f51385dc07cf31fcf43ecb020700e309e

**Current behavior before PR**
Publication reports allow only portrait printing.

**Desired behavior after PR is merged**
A new checkbox "landscape" allows to switch the dimensions for landscape printing.
