### PR TITLE
Fix analysis_workflow permissions for Field Analysis Results

### DIFF
--- a/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_analysis_workflow/definition.xml
@@ -42,6 +42,7 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>RegulatoryInspector</permission-role>
+      <permission-role>Sampler</permission-role>
     </permission-map>
   </state>
 
@@ -52,9 +53,9 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="BIKA: Edit Field Results" acquired="True">
+    <permission-map name="BIKA: Edit Field Results" acquired="False">
     </permission-map>
-    <permission-map name="BIKA: Edit Results" acquired="True">
+    <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: View Results" acquired="False">
       <permission-role>Analyst</permission-role>
@@ -116,12 +117,12 @@
       <permission-role>Owner</permission-role>
     </permission-map>
     <permission-map name="BIKA: Edit Field Results" acquired="False">
+      <permission-role>Analyst</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
-      <permission-role>LabClerk</permission-role>
       <permission-role>Sampler</permission-role>
-    </permission-map>
-    <permission-map name="BIKA: Edit Results" acquired="True">
+   </permission-map>
+    <permission-map name="BIKA: Edit Results" acquired="False">
     </permission-map>
     <permission-map name="BIKA: Receive Sample" acquired="True">
       <permission-role>LabClerk</permission-role>
@@ -150,7 +151,11 @@
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
     </permission-map>
-    <permission-map name="BIKA: Edit Field Results" acquired="True">
+    <permission-map name="BIKA: Edit Field Results" acquired="False">
+      <permission-role>Analyst</permission-role>
+      <permission-role>LabManager</permission-role>
+      <permission-role>Manager</permission-role>
+      <permission-role>Sampler</permission-role>
     </permission-map>
     <permission-map name="BIKA: Edit Results" acquired="False">
       <permission-role>Analyst</permission-role>
@@ -187,7 +192,7 @@
       <permission-role>Manager</permission-role>
     </permission-map>
     <permission-map name="BIKA: Edit Field Results" acquired="False">
-      <permission-role>LabClerk</permission-role>
+      <permission-role>Analyst</permission-role>
       <permission-role>LabManager</permission-role>
       <permission-role>Manager</permission-role>
       <permission-role>Sampler</permission-role>


### PR DESCRIPTION
Reported at https://jira.bikalabs.com/browse/AN-147, these incorrect permissions
allow the analysis to remain editable after submission or retraction.

(cherry picked from commit 15779a8ffe44680d5e00b9a391ce4ac8c4452d53)

I believe that acquiring permissions in workflows is evil, but I have only made modifications related to fixing the roles of the "Edit Field Results" permission of analysis workflow.

I'm requesting this against senaite-integration because the other branches don't yet use the xml format for workflow configuration.