### PR TITLE
PR-1931: LIMS-2473: Fixed Link User to Contact: LDAP Users not found (#1931)

### DIFF
--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -95,8 +95,8 @@ class ContactLoginDetailsView(BrowserView):
         """Search Plone users which are not linked to a contact or lab contact
         """
         acl_users = api.portal.get_tool("acl_users")
-        # expected groups for client contacts
         users = acl_users.searchUsers()
+        # expected groups for client contacts
         client_contact_groups = {'AuthenticatedUsers', 'Clients'}
         out = []
         for user in users:

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -136,7 +136,7 @@ class ContactLoginDetailsView(BrowserView):
             # filter out users which do not match the searchstring
             if self.searchstring:
                 s = self.searchstring.lower()
-                if not any(map(lambda v: re.search(s, v.lower()), userdata.values())):
+                if not any(map(lambda v: re.search(s, str(v).lower()), userdata.values())):
                     continue
 
             # update data (maybe for later use)

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -13,6 +13,7 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from plone import api
+from plone.app.controlpanel.usergroups import UsersOverviewControlPanel
 from plone.protect import CheckAuthenticator
 
 from bika.lims import PMF
@@ -94,10 +95,15 @@ class ContactLoginDetailsView(BrowserView):
     def linkable_users(self):
         """Search Plone users which are not linked to a contact or lab contact
         """
-        acl_users = api.portal.get_tool("acl_users")
-        users = acl_users.searchUsers()
+
+        # We make use of the existing controlpanel `@@usergroup-userprefs` view
+        # logic to make sure we get all users from all plugins (e.g. LDAP)
+        users_view = UsersOverviewControlPanel(self.context, self.request)
+
         # expected groups for client contacts
         client_contact_groups = {'AuthenticatedUsers', 'Clients'}
+
+        users = users_view.doSearch("")
         out = []
         for user in users:
             userid = user.get("id", None)

--- a/bika/lims/browser/contact.py
+++ b/bika/lims/browser/contact.py
@@ -196,11 +196,13 @@ class ContactLoginDetailsView(BrowserView):
     def _create_user(self):
         """Create a new user
         """
+
         def error(field, message):
             if field:
                 message = "%s: %s" % (field, message)
             self.context.plone_utils.addPortalMessage(message, 'error')
-            return self.template()
+            return self.request.response.redirect(
+                self.context.absolute_url() + "/login_details")
 
         form = self.request.form
         contact = self.context
@@ -217,8 +219,7 @@ class ContactLoginDetailsView(BrowserView):
             return error('email', PMF("Input is required but not given."))
 
         reg_tool = self.context.portal_registration
-        properties = self.context.portal_properties.site_properties
-
+        # properties = self.context.portal_properties.site_properties
         # if properties.validate_email:
         #     password = reg_tool.generatePassword()
         # else:
@@ -252,7 +253,8 @@ class ContactLoginDetailsView(BrowserView):
             return error(None, msg)
 
         contact.setUser(username)
-
+        # TODO: Not sure if this is the correct behaviour after
+        # senaite-integration since there have been changes in permissions.
         # If we're being created in a Client context, then give
         # the contact an Owner local role on client.
         if contact.aq_parent.portal_type == 'Client':
@@ -279,12 +281,13 @@ class ContactLoginDetailsView(BrowserView):
                 reg_tool.registeredNotify(username)
             except:
                 transaction.abort()
-                return error(
-                    None, PMF("SMTP server disconnected."))
+                message = _("SMTP server disconnected. User creation aborted.")
+                return error(None, message)
         contact.reindexObject()
-        message = PMF("Member registered.")
+        message = _("Member registered and linked to the current Contact.")
         self.context.plone_utils.addPortalMessage(message, 'info')
-        return self.template()
+        return self.request.response.redirect(
+            self.context.absolute_url() + "/login_details")
 
     def tabindex(self):
         i = 0

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -46,7 +46,12 @@
             <span tal:replace="structure context/@@authenticator/authenticator"/>
             <input type="hidden" name="submitted" value="1"/>
 
-            <table class="plain">
+            <div class="field error" tal:condition="not: userprops" i18n:translate="">
+              No user profile could be found for the linked user.
+              Please contact the lab administrator to get further support or try to relink the user.
+            </div>
+
+            <table class="plain" tal:condition="userprops">
               <tbody>
                 <tr>
                   <td rowspan="5">

--- a/bika/lims/browser/templates/login_details.pt
+++ b/bika/lims/browser/templates/login_details.pt
@@ -5,126 +5,124 @@
       metal:use-macro="here/main_template/macros/master"
       i18n:domain="bika">
 
-<body>
+  <body>
 
-<metal:title fill-slot="content-title">
-    <h1 i18n:translate="">Login details</h1>
-</metal:title>
+    <metal:title fill-slot="content-title">
+      <h1 i18n:translate="">Login details</h1>
+    </metal:title>
 
-<metal:content fill-slot="content-core"
-               tal:define="portal context/@@plone_portal_state/portal;
-                           has_user context/hasUser;
-                           tabindex view/tabindex;">
+    <metal:content fill-slot="content-core"
+                   tal:define="portal context/@@plone_portal_state/portal;
+                               has_user context/hasUser;
+                               tabindex view/tabindex;">
 
-
-    <!-- Contact has a linked User -->
-    <tal:withuser condition="has_user"
-                  define="userprops    view/get_user_properties;
-                          contactprops view/get_contact_properties;
-                          active       context/isActive;
-                          inactive     not: active">
+      <!-- Contact has a linked User -->
+      <tal:withuser condition="has_user"
+                    define="userprops    view/get_user_properties;
+                            contactprops view/get_contact_properties;
+                            active       context/isActive;
+                            inactive     not: active">
 
         <p i18n:translate="">
-            <span tal:content="contactprops/fullname"
-                    i18n:name="contact_fullname">
-                Pete Smith
-            </span>
-            can log into the LIMS by using
-            <strong tal:content="contactprops/username"
-                    i18n:name="contact_username">
-                username
-            </strong>
-            as username. Contacts must change their own passwords.
-            If a password is forgotten a contact can request a new password from the login form.
+          <span tal:content="contactprops/fullname"
+                i18n:name="contact_fullname">
+            Pete Smith
+          </span>
+          can log into the LIMS by using
+          <strong tal:content="contactprops/username"
+                  i18n:name="contact_username">
+            username
+          </strong>
+          as username. Contacts must change their own passwords.
+          If a password is forgotten a contact can request a new password from the login form.
         </p>
 
-
         <fieldset>
-            <legend i18n:translate="">Manage linked User</legend>
+          <legend i18n:translate="">Manage linked User</legend>
 
-            <form id="contact_edit_form"
-                  method="post">
+          <form id="contact_edit_form"
+                method="post">
 
-                <span tal:replace="structure context/@@authenticator/authenticator"/>
-                <input type="hidden" name="submitted" value="1"/>
+            <span tal:replace="structure context/@@authenticator/authenticator"/>
+            <input type="hidden" name="submitted" value="1"/>
 
-                <table class="plain">
-                    <tbody>
-                        <tr>
-                            <td rowspan="5">
-                                <img tal:replace="structure userprops/portrait"/>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span i18n:translate="">Full Name</span>
-                            </td>
-                            <td>
-                                <span tal:replace="userprops/fullname"></span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span i18n:translate="">User Name</span>
-                            </td>
-                            <td>
-                                <tal:labcontact condition="view/is_labcontact">
-                                <a href="#"
-                                   tal:attributes="href userprops/edit_url">
-                                    <span tal:replace="userprops/id">labuser</span>
-                                </a>
-                                </tal:labcontact>
-                                <tal:contact condition="view/is_contact">
-                                    <span tal:replace="userprops/id">customeruser</span>
-                                </tal:contact>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span i18n:translate="">Email</span>
-                            </td>
-                            <td>
-                                <a href="#"
-                                   tal:attributes="href string:mailto:${userprops/email}"
-                                   tal:content="userprops/email">labcontact@bikalims.com</a>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>
-                                <span i18n:translate="">Last Login Time</span>
-                            </td>
-                            <td>
-                                <span tal:replace="python:context.toLocalizedTime(userprops['last_login_time'], long_format=1)"></span>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
+            <table class="plain">
+              <tbody>
+                <tr>
+                  <td rowspan="5">
+                    <img tal:replace="structure userprops/portrait"/>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <span i18n:translate="">Full Name</span>
+                  </td>
+                  <td>
+                    <span tal:replace="userprops/fullname"></span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <span i18n:translate="">User Name</span>
+                  </td>
+                  <td>
+                    <tal:labcontact condition="view/is_labcontact">
+                      <a href="#"
+                         tal:attributes="href userprops/edit_url">
+                        <span tal:replace="userprops/id">labuser</span>
+                      </a>
+                    </tal:labcontact>
+                    <tal:contact condition="view/is_contact">
+                      <span tal:replace="userprops/id">customeruser</span>
+                    </tal:contact>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <span i18n:translate="">Email</span>
+                  </td>
+                  <td>
+                    <a href="#"
+                       tal:attributes="href string:mailto:${userprops/email}"
+                       tal:content="userprops/email">labcontact@bikalims.com</a>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <span i18n:translate="">Last Login Time</span>
+                  </td>
+                  <td>
+                    <span tal:replace="python:context.toLocalizedTime(userprops['last_login_time'], long_format=1)"></span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
 
-                <!-- Form Controls -->
-                <div class="formControls" tal:condition="active">
-                    <input class="context"
-                           style="color:red;"
-                           type="submit"
-                           tabindex=""
-                           name="delete_button"
-                           value="Unlink and delete User"
-                           i18n:attributes="value"
-                           tal:attributes="tabindex tabindex/next;" />
-                    <input class="context"
-                           type="submit"
-                           tabindex=""
-                           name="unlink_button"
-                           value="Unlink User"
-                           i18n:attributes="value"
-                           tal:attributes="tabindex tabindex/next;" />
-                </div>
-                <p tal:condition="inactive">
-                    <img src="++resource++bika.lims.images/exclamation2.png" title="Disabled Contact">
-                    <span i18n:translate="" class="discreet">
-                        Contact is deactivated. User cannot be unlinked.
-                    </span>
-                </p>
-            </form>
+            <!-- Form Controls -->
+            <div class="formControls" tal:condition="active">
+              <input class="context"
+                     style="color:red;"
+                     type="submit"
+                     tabindex=""
+                     name="delete_button"
+                     value="Unlink and delete User"
+                     i18n:attributes="value"
+                     tal:attributes="tabindex tabindex/next;" />
+              <input class="context"
+                     type="submit"
+                     tabindex=""
+                     name="unlink_button"
+                     value="Unlink User"
+                     i18n:attributes="value"
+                     tal:attributes="tabindex tabindex/next;" />
+            </div>
+            <p tal:condition="inactive">
+              <img src="++resource++bika.lims.images/exclamation2.png" title="Disabled Contact">
+              <span i18n:translate="" class="discreet">
+                Contact is deactivated. User cannot be unlinked.
+              </span>
+            </p>
+          </form>
         </fieldset>
     </tal:withuser>
     <!-- /Contact has a linked User -->
@@ -133,173 +131,171 @@
     <tal:withoutuser condition="not:has_user"
                      define="contactprops view/get_contact_properties;">
 
-        <p i18n:translate="">
-            No user exists for
-            <span tal:content="here/getFullname" i18n:name="contact_fullname">Pete Smith</span>
-            and he/she will not be able to log in. Fill in the form below to create one for him/her.
+      <p i18n:translate="">
+        No user exists for
+        <span tal:content="here/getFullname" i18n:name="contact_fullname">Pete Smith</span>
+        and he/she will not be able to log in. Fill in the form below to create one for him/her.
+      </p>
+
+      <fieldset
+          tal:define="Batch python:modules['plone.batching'].Batch;
+                      b_size python:5;
+                      b_start python:0 if view.newSearch else request.get('b_start', 0);
+                      batch python:Batch(view.linkable_users(), b_size, int(b_start), orphan=1) or None;
+                      batchformkeys python:['_authenticator'];">
+
+        <legend i18n:translate="">Link an existing User</legend>
+        <p tal:condition="view/is_contact"
+           i18n:translate="">
+            Only existing users in "Client" group are displayed.
         </p>
+        <form id="user_search_form"
+              method="post">
 
-        <fieldset
-            tal:define="Batch python:modules['plone.batching'].Batch;
-                        b_size python:5;
-                        b_start python:0 if view.newSearch else request.get('b_start', 0);
-                        batch python:Batch(view.linkable_users(), b_size, int(b_start), orphan=1) or None;
-                        batchformkeys python:['_authenticator'];">
+          <input tal:replace="structure context/@@authenticator/authenticator"/>
+          <input type="hidden" name="submitted" value="1"/>
 
-            <legend i18n:translate="">Link an existing User</legend>
-            <p tal:condition="view/is_contact"
-               i18n:translate="">
-                Only existing users in "Client" group are displayed.
-            </p>
-            <form id="user_search_form"
-                  method="post">
+          <table class="listing">
+            <thead>
+              <tr>
+                <th colspan="4" class="nosort">
+                  <input class="quickSearch" type="text" name="searchstring" value="" tal:attributes="value view/searchstring">
+                            <input type="submit" class="searchButton"
+                                   name="search_button" value="Search">
+                </th>
+              </tr>
+              <tr>
+                <th class="nosort"></th>
+                <th i18n:translate="">Full Name</th>
+                <th i18n:translate="">Email</th>
+                <th i18n:translate="">User Name</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr tal:repeat="user batch">
+                <td>
+                  <input type="radio"
+                         name="userid"
+                         value=""
+                         tal:attributes="value user/userid">
+                </td>
+                <td tal:content="user/fullname">Fullname</td>
+                <td>
+                  <a href="#"
+                     tal:attributes="href string:mailto:${user/email}"
+                     tal:content="user/email"></a>
+                </td>
+                <td>
+                  <span tal:replace="user/userid">customeruser</span>
+                </td>
 
-                <input tal:replace="structure context/@@authenticator/authenticator"/>
-                <input type="hidden" name="submitted" value="1"/>
+              </tr>
+            </tbody>
+          </table>
 
-                <table class="listing">
-                    <thead>
-                        <tr>
-                            <th colspan="4" class="nosort">
-                                <input class="quickSearch" type="text" name="searchstring" value="" tal:attributes="value view/searchstring">
-                                <input type="submit" class="searchButton"
-                                       name="search_button" value="Search">
-                            </th>
-                        </tr>
-                        <tr>
-                            <th class="nosort"></th>
-                            <th i18n:translate="">Full Name</th>
-                            <th i18n:translate="">Email</th>
-                            <th i18n:translate="">User Name</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr tal:repeat="user batch">
-                            <td>
-                                <input type="radio"
-                                       name="userid"
-                                       value=""
-                                       tal:attributes="value user/userid">
-                            </td>
-                            <td tal:content="user/fullname">Fullname</td>
-                            <td>
-                                <a href="#"
-                                   tal:attributes="href string:mailto:${user/email}"
-                                   tal:content="user/email"></a>
-                                </td>
-                                <td>
-                                    <span tal:replace="user/userid">customeruser</span>
-                                </td>
+          <div class="discreet">
+            <tal:batchnavigation
+                define="batchnavigation nocall:context/@@batchnavigation"
+                replace="structure python:batchnavigation(batch, batchformkeys)" />
+          </div>
 
-                        </tr>
-                    </tbody>
-                </table>
+          <!-- Form Controls -->
+          <div class="formControls">
+            <input class="context allowMultiSubmit"
+                   type="submit"
+                   tabindex=""
+                   name="link_button"
+                   value="Link User"
+                   i18n:attributes="value"
+                   tal:attributes="tabindex tabindex/next;" />
+          </div>
+        </form>
+      </fieldset>
 
-                <div class="discreet">
-                    <tal:batchnavigation
-                        define="batchnavigation nocall:context/@@batchnavigation"
-                        replace="structure python:batchnavigation(batch, batchformkeys)" />
-                </div>
+      <fieldset>
+        <legend i18n:translate="">Create a new User</legend>
 
-                <!-- Form Controls -->
-                <div class="formControls">
-                    <input class="context allowMultiSubmit"
-                           type="submit"
-                           tabindex=""
-                           name="link_button"
-                           value="Link User"
-                           i18n:attributes="value"
-                           tal:attributes="tabindex tabindex/next;" />
-                </div>
-            </form>
-        </fieldset>
+        <form id="contact_edit_form"
+              method="post">
 
-        <fieldset>
-            <legend i18n:translate="">Create a new User</legend>
+          <span tal:replace="structure context/@@authenticator/authenticator"/>
+          <input type="hidden" name="submitted" value="1"/>
+          <input type="hidden" name="fullname" value="fullname" tal:attributes="value here/getFullname"/>
 
-            <form id="contact_edit_form"
-                  method="post">
+          <div class="field">
+            <label i18n:translate="">User Name</label>
+            <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
+            <div i18n:translate="">
+              Enter a user name, usually something like
+              'jsmith'. No spaces or special characters.
+              Usernames and passwords are case sensitive,
+              make sure the caps lock key is not enabled.
+              This is the name used to log in.
+            </div>
+            <input type="text" name="username" size="30" tal:attributes="value python:view.request.get('username', '')"/>
+          </div>
 
-                <span tal:replace="structure context/@@authenticator/authenticator"/>
-                <input type="hidden" name="submitted" value="1"/>
-                <input type="hidden" name="fullname" value="fullname" tal:attributes="value here/getFullname"/>
+          <!--<tal:password condition="not:context/portal_properties/site_properties/validate_email|nothing">-->
+          <div class="field" tal:condition="python:context.portal_membership.checkPermission('Add portal member', context)">
+            <label i18n:translate="">Password</label>
+            <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
+            <div class="formHelp" i18n:translate="">
+              Minimum 5 characters.
+            </div>
+            <input type="password" name="password" size="10"/>
+          </div>
 
+          <div class="field" tal:condition="python:context.portal_membership.checkPermission('Add portal member', context)">
+            <label i18n:translate="">Confirm password</label>
+            <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
+            <div class="formHelp" i18n:translate="">
+              Re-enter the password. Make sure the passwords are identical.
+            </div>
+            <input type="password" name="confirm" size="10"/>
+          </div>
+          <!--			</tal:password>-->
 
-                <div class="field">
-                    <label i18n:translate="">User Name</label>
-                    <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
-                    <div i18n:translate="">
-                        Enter a user name, usually something like
-                        'jsmith'. No spaces or special characters.
-                        Usernames and passwords are case sensitive,
-                        make sure the caps lock key is not enabled.
-                        This is the name used to log in.
-                    </div>
-                    <input type="text" name="username" size="30" tal:attributes="value python:view.request.get('username', '')"/>
-                </div>
+          <div class="field">
+            <label i18n:translate="">Email</label>
+            <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
+            <div class="formHelp" i18n:translate="">
+              Enter an email address. This is necessary in case the password
+              is lost. We respect your privacy, and will not give the address
+              away to any third parties or expose it anywhere.
+            </div>
+            <input type="text" name="email" size="30" tal:attributes="value python: context.getEmailAddress() and context.getEmailAddress() or view.request.get('email', '')"/> </div>
 
+            <div class="field"
+                 tal:condition="view/is_labcontact">
+              <label i18n:translate="label_add_to_groups">Add to the following groups:</label>
+              <span class="fieldRequired" i18n:translate="">(Required)</span>
+              <br/>
+              <select name="groups" size="10" multiple="1">
+                <option value='LabManagers'>LabManagers</option>
+                <option value='LabClerks'>LabClerks</option>
+                <option value='Analysts'>Analysts</option>
+                <option value='Verifiers'>Verifiers</option>
+                <option value='Samplers'>Samplers</option>
+                <option value='Preservers'>Preservers</option>
+                <option value='Publishers'>Publishers</option>
+                <option value='Reviewers'>Reviewers</option>
+              </select>
+            </div>
 
-                <!--<tal:password condition="not:context/portal_properties/site_properties/validate_email|nothing">-->
-                <div class="field" tal:condition="python:context.portal_membership.checkPermission('Add portal member', context)">
-                    <label i18n:translate="">Password</label>
-                    <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
-                    <div class="formHelp" i18n:translate="">
-                        Minimum 5 characters.
-                    </div>
-                    <input type="password" name="password" size="10"/>
-                </div>
+            <input class="context allowMultiSubmit"
+                   type="submit"
+                   tabindex=""
+                   name="save_button"
+                   value="Save"
+                   i18n:attributes="value"
+                   tal:attributes="tabindex tabindex/next;" />
 
-                <div class="field" tal:condition="python:context.portal_membership.checkPermission('Add portal member', context)">
-                    <label i18n:translate="">Confirm password</label>
-                    <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
-                    <div class="formHelp" i18n:translate="">
-                        Re-enter the password. Make sure the passwords are identical.
-                    </div>
-                    <input type="password" name="confirm" size="10"/>
-                </div>
-                <!--			</tal:password>-->
-
-                <div class="field">
-                    <label i18n:translate="">Email</label>
-                    <span class="fieldRequired" title="Required" i18n:attributes="title" i18n:translate="">(Required)</span>
-                    <div class="formHelp" i18n:translate="">
-                        Enter an email address. This is necessary in case the password
-                        is lost. We respect your privacy, and will not give the address
-                        away to any third parties or expose it anywhere.
-                    </div>
-                    <input type="text" name="email" size="30" tal:attributes="value python: context.getEmailAddress() and context.getEmailAddress() or view.request.get('email', '')"/> </div>
-
-                    <div class="field"
-                         tal:condition="view/is_labcontact">
-                        <label i18n:translate="label_add_to_groups">Add to the following groups:</label>
-                        <span class="fieldRequired" i18n:translate="">(Required)</span>
-                        <br/>
-                        <select name="groups" size="10" multiple="1">
-                            <option value='LabManagers'>LabManagers</option>
-                            <option value='LabClerks'>LabClerks</option>
-                            <option value='Analysts'>Analysts</option>
-                            <option value='Verifiers'>Verifiers</option>
-                            <option value='Samplers'>Samplers</option>
-                            <option value='Preservers'>Preservers</option>
-                            <option value='Publishers'>Publishers</option>
-                            <option value='Reviewers'>Reviewers</option>
-                        </select>
-                    </div>
-
-                    <input class="context allowMultiSubmit"
-                           type="submit"
-                           tabindex=""
-                           name="save_button"
-                           value="Save"
-                           i18n:attributes="value"
-                           tal:attributes="tabindex tabindex/next;" />
-
-            </form>
-        </fieldset>
+        </form>
+      </fieldset>
     </tal:withoutuser>
     <!-- /Contact has **no** linked User -->
 
-</metal:content>
+  </metal:content>
 
 </body>
 

--- a/bika/lims/docs/ContactUser.rst
+++ b/bika/lims/docs/ContactUser.rst
@@ -1,0 +1,200 @@
+==================================
+Clients, Contacts and linked Users
+==================================
+
+Clients are the customers of the lab. A client represents another company, which
+has one or more natural persons as contacts.
+
+Each contact can be linked to a Plone system user. The linking process adds the
+linked user to the "Clients" group, which has the "Customer" role.
+
+Furthermore, the user gets  the local "Owner" role for the owning client object.
+
+
+Test Setup
+==========
+
+    >>> import transaction
+    >>> from plone import api as ploneapi
+    >>> from zope.lifecycleevent import modified
+    >>> from AccessControl.PermissionRole import rolesForPermissionOn
+    >>> from plone.app.testing import TEST_USER_ID
+    >>> from plone.app.testing import TEST_USER_PASSWORD
+
+    >>> portal = self.getPortal()
+    >>> portal_url = portal.absolute_url()
+    >>> bika_setup = portal.bika_setup
+    >>> bika_setup_url = portal_url + "/bika_setup"
+    >>> browser = self.getBrowser()
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def login(user=TEST_USER_ID, password=TEST_USER_PASSWORD):
+    ...     browser.open(portal_url + "/login_form")
+    ...     browser.getControl(name='__ac_name').value = user
+    ...     browser.getControl(name='__ac_password').value = password
+    ...     browser.getControl(name='submit').click()
+    ...     assert("__ac_password" not in browser.contents)
+
+    >>> def logout():
+    ...     browser.open(portal_url + "/logout")
+    ...     assert("You are now logged out" in browser.contents)
+
+    >>> def get_roles_for_permission(permission, context):
+    ...     allowed = set(rolesForPermissionOn(permission, context))
+    ...     return sorted(allowed)
+
+    >>> def create(container, portal_type, title=None):
+    ...     # Creates a content in a container and manually calls processForm
+    ...     title = title is None and "Test {}".format(portal_type) or title
+    ...     _ = container.invokeFactory(portal_type, id="tmpID", title=title)
+    ...     obj = container.get(_)
+    ...     obj.processForm()
+    ...     modified(obj)  # notify explicitly for the test
+    ...     transaction.commit()  # somehow the created method did not appear until I added this
+    ...     return obj
+
+    >>> def get_workflows_for(context):
+    ...     # Returns a tuple of assigned workflows for the given context
+    ...     workflow = ploneapi.portal.get_tool("portal_workflow")
+    ...     return workflow.getChainFor(context)
+
+    >>> def get_workflow_status_of(context):
+    ...     # Returns the workflow status of the given context
+    ...     return ploneapi.content.get_state(context)
+
+
+Client
+======
+
+A `client` lives in the `/clients` folder::
+
+    >>> clients = portal.clients
+    >>> client1 = create(clients, "Client", title="Client-1")
+    >>> client2 = create(clients, "Client", title="Client-2")
+
+
+Contact
+=======
+
+A `contact` lives inside a `client`::
+
+    >>> contact1 = create(client1, "Contact", "Contact-1")
+    >>> contact2 = create(client2, "Contact", "Contact-2")
+
+
+User
+====
+
+A `user` is able to login to the system.
+
+Create a new user for the contact::
+
+    >>> user1 = ploneapi.user.create(email="contact-1@example.com", username="contact-1", password=TEST_USER_PASSWORD, properties=dict(fullname="Test User 1"))
+    >>> user2 = ploneapi.user.create(email="contact-2@example.com", username="contact-2", password=TEST_USER_PASSWORD, properties=dict(fullname="Test User 2"))
+    >>> transaction.commit()
+
+
+Client Browser Test
+-------------------
+
+Login with the first user::
+
+    >>> login(user1.id)
+
+The user is not allowed to access any clients folder::
+
+    >>> browser.open(clients.absolute_url())
+    >>> "client-1" not in browser.contents
+    True
+    >>> "client-2" not in browser.contents
+    True
+
+    >>> browser.open(client1.absolute_url())
+    Traceback (most recent call last):
+    ...
+    Unauthorized: ...
+
+Linking the user to a client contact grants access to this client::
+
+    >>> contact1.setUser(user1)
+    True
+    >>> transaction.commit()
+
+Linking a user adds this user to the `Clients` group::
+
+    >>> clients_group = ploneapi.group.get("Clients")
+    >>> user1 in clients_group.getAllGroupMembers()
+    True
+
+This gives the user the global `Client` role::
+
+    >>> sorted(ploneapi.user.get_roles(user=user1))
+    ['Authenticated', 'Client', 'Member']
+
+It also grants local `Owner` role on the client object::
+
+    >>> sorted(user1.getRolesInContext(client1))
+    ['Authenticated', 'Member', 'Owner']
+
+This allows the user to see the client in the clients folder::
+
+    >>> browser.open(clients.absolute_url())
+    >>> "client-1" in browser.contents
+    True
+
+But not any other client in the clients folder
+
+    >>> "client-2" not in browser.contents
+    True
+
+The user is able to modify the `client` object properties::
+
+    >>> browser.open(client1.absolute_url() + "/base_edit")
+    >>> "edit_form" in browser.contents
+    True
+
+As well as the `contact` object properties::
+
+    >>> browser.open(contact1.absolute_url() + "/base_edit")
+    >>> "edit_form" in browser.contents
+    True
+
+But the user can not access other clients::
+
+    >>> browser.open(client2.absolute_url())
+    Traceback (most recent call last):
+    ...
+    Unauthorized: ...
+
+Or modify other clients::
+
+    >>> browser.open(client2.absolute_url() + "/base_edit")
+    Traceback (most recent call last):
+    ...
+    Unauthorized: ...
+
+Unlink the user revokes all access to the client::
+
+    >>> contact1.unlinkUser()
+    True
+    >>> transaction.commit()
+
+The user has no local owner role anymore on the client::
+
+    >>> sorted(user1.getRolesInContext(client1))
+    ['Authenticated', 'Member']
+
+The user can not access the `client` anymore::
+
+    >>> browser.open(clients.absolute_url())
+    >>> "client-1" not in browser.contents
+    True
+
+    >>> browser.open(client1.absolute_url())
+    Traceback (most recent call last):
+    ...
+    Unauthorized: ...

--- a/bika/lims/tests/test_textual_doctests.py
+++ b/bika/lims/tests/test_textual_doctests.py
@@ -20,6 +20,7 @@ rst_filenames = [f for f in resource_listdir(PROJECTNAME, "tests/doctests")
 doctests = [join("doctests", filename) for filename in rst_filenames]
 
 flags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE | doctest.REPORT_NDIFF
+    "../docs/ContactUser.rst",
 
 
 def test_suite():


### PR DESCRIPTION
*From original PR: plone.api.user.get_user() didn't find users located in ldap

This PR, contains the following:
- Now contact view is able to search users located in LDAP
- Users created from client context receive **owner permissions** in order to have access to only that specific client. @ramonski was this fixed during permissions refactory?
- login_details.pt reformatting.
- Contact user creation fixes
- ContactUsers tests