### PR TITLE
Fix sorting of Analysis Services list and disable manual sorting

### DIFF
--- a/bika/lims/catalog/indexers/analysisservice.py
+++ b/bika/lims/catalog/indexers/analysisservice.py
@@ -1,11 +1,14 @@
 from bika.lims.interfaces import IAnalysisService
 from plone.indexer import indexer
+from Products.CMFPlone.CatalogTool import sortable_title as _sortable_title
 
 
 @indexer(IAnalysisService)
 def sortable_title(instance):
     sort_key = instance.getSortKey()
-    try:
-        return "{:010.3f}{}".format(sort_key, instance.Title())
-    except (ValueError, TypeError):
-        return instance.Title()
+    if not sort_key:
+        sort_key = 999999
+    title = _sortable_title(instance)
+    if callable(title):
+        title = title()
+    return "{:010.3f}{}".format(sort_key, title)

--- a/bika/lims/catalog/indexers/analysisservice.py
+++ b/bika/lims/catalog/indexers/analysisservice.py
@@ -6,7 +6,7 @@ from Products.CMFPlone.CatalogTool import sortable_title as _sortable_title
 @indexer(IAnalysisService)
 def sortable_title(instance):
     sort_key = instance.getSortKey()
-    if not sort_key:
+    if sort_key is not None:
         sort_key = 999999
     title = _sortable_title(instance)
     if callable(title):

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -139,7 +139,7 @@ class AnalysisServicesView(BikaListingView):
         self.an_cats = None
         self.an_cats_order = None
         self.catalog = 'bika_setup_catalog'
-        self.contentFilter = {'portal_type': 'AnalysisService', }
+        self.contentFilter = {'portal_type': 'AnalysisService'}
         self.context_actions = {
             _('Add'):
                 {'url': 'createObject?type_name=AnalysisService',
@@ -167,57 +167,70 @@ class AnalysisServicesView(BikaListingView):
                 'title': _('Service'),
                 'index': 'sortable_title',
                 'replace_url': 'absolute_url',
+                'sortable': not self.do_cats,
             },
             'Keyword': {
                 'title': _('Keyword'),
                 'index': 'getKeyword',
-                'attr': 'getKeyword'
+                'attr': 'getKeyword',
+                'sortable': not self.do_cats,
             },
             'Category': {
                 'title': _('Category'),
-                'attr': 'getCategoryTitle'
+                'attr': 'getCategoryTitle',
+                'sortable': not self.do_cats,
             },
             'Method': {
                 'title': _('Method'),
                 'attr': 'getMethod.Title',
                 'replace_url': 'getMethod.absolute_url',
+                'sortable': not self.do_cats,
                 'toggle': False
             },
             'Department': {
                 'title': _('Department'),
                 'toggle': False,
-                'attr': 'getDepartment.Title'
+                'attr': 'getDepartment.Title',
+                'sortable': not self.do_cats,
             },
             'Instrument': {
-                'title': _('Instrument')
+                'title': _('Instrument'),
+                'sortable': not self.do_cats,
             },
             'Unit': {
                 'title': _('Unit'),
-                'attr': 'getUnit'
+                'attr': 'getUnit',
+                'sortable': False,
             },
             'Price': {
-                'title': _('Price')
+                'title': _('Price'),
+                'sortable': not self.do_cats,
             },
             'MaxTimeAllowed': {
                 'title': _('Max Time'),
-                'toggle': False
+                'toggle': False,
+                'sortable': not self.do_cats,
             },
             'DuplicateVariation': {
                 'title': _('Dup Var'),
-                'toggle': False
+                'toggle': False,
+                'sortable': False,
              },
             'Calculation': {
-                'title': _('Calculation')
+                'title': _('Calculation'),
+                'sortable': False,
             },
             'CommercialID': {
                 'title': _('Commercial ID'),
                 'attr': 'getCommercialID',
-                'toggle': True
+                'toggle': True,
+                'sortable': not self.do_cats,
             },
             'ProtocolID': {
                 'title': _('Protocol ID'),
                 'attr': 'getProtocolID',
-                'toggle': True
+                'toggle': True,
+                'sortable': not self.do_cats,
             },
             'SortKey': {
                 'title': _('Sort Key'),


### PR DESCRIPTION
With this PR, when sorting Analysis Services by sortable_title, the items with sortkey value defined will appear first and sorted by sortkey ascendant. The rest of items will appear below, sorted by title ascending. 

This PR also takes into account the inconsistencies in the sort order amongst Analysis Services with lower and uppercase titles.

If the categorization of Analysis Services is disabled, the list can be sorted manually. Otherwise, the list renders with no sortable columns.