### PR TITLE
PR 2130 & PR 2233

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ LIMS-1504: Calculation formula test widgets
 
 **Fixed**
 
+- #309 Integration of PR-2130, PR-2233
+       Infinite Recursion on Report Publication.
+       Copied ARs are created in random order.
 - #304 Integration of PR-2053, PR-2080.
        Computed Sample Field "SampleTypeUID" does not check if a SampleType is set.
        Batch Book raises an Error if the Batch inherits from 2 ARs.

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -1252,8 +1252,18 @@ class AnalysisRequestDigester:
                     'pubpref': contact.getPublicationPreference()}
         return data
 
-    def _client_address(self, client):
+    def _client_address(self, ar):
+        client = ar.aq_parent
         client_address = client.getPostalAddress()
+        if not client_address:
+            if not IAnalysisRequest.providedBy(ar):
+                return ""
+            # Data from the first contact
+            contact = ar.getContact()
+            if contact and contact.getBillingAddress():
+                client_address = contact.getBillingAddress()
+            elif contact and contact.getPhysicalAddress():
+                client_address = contact.getPhysicalAddress()
         return self._format_address(client_address)
 
     def _client_data(self, ar):
@@ -1267,7 +1277,7 @@ class AnalysisRequestDigester:
             data['phone'] = to_utf8(client.getPhone())
             data['fax'] = to_utf8(client.getFax())
 
-            data['address'] = to_utf8(self._client_address(client))
+            data['address'] = to_utf8(self._client_address(ar))
         return data
 
     def _specs_data(self, ar):

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -640,25 +640,7 @@ class AnalysisRequestPublishView(BrowserView):
         lab_address = lab.getPostalAddress() \
                       or lab.getBillingAddress() \
                       or lab.getPhysicalAddress()
-        return self._format_address(lab_address)
-
-    def _client_address(self, client):
-        client_address = client.getPostalAddress() \
-                         or client.getBillingAddress() \
-                         or client.getPhysicalAddress()
-        return self._format_address(client_address)
-
-    def _format_address(self, address):
-        """Takes a value from an AddressField, returns a div class=address
-        with spans inside, containing the address field values.
-        """
-        addr = ''
-        if address:
-            # order of divs in output html
-            keys = ['address', 'city', 'district', 'state', 'zip', 'country']
-            addr = ''.join(["<span>%s</span>" % address.get(v) for v in keys
-                            if address.get(v, None)])
-        return "<div class='address'>%s</div>" % addr
+        return _format_address(lab_address)
 
     def explode_data(self, data, padding=''):
         out = ''
@@ -844,7 +826,7 @@ class AnalysisRequestDigester:
 
             elif fld.type == 'address':
                 # This is just a Record field
-                data[fieldname + "_formatted"] = self._format_address(rawvalue)
+                data[fieldname + "_formatted"] = _format_address(rawvalue)
                 # Also include un-formatted address
                 data[fieldname] = rawvalue
 
@@ -860,18 +842,6 @@ class AnalysisRequestDigester:
                 data[fieldname] = rawvalue
 
         return data
-
-    def _format_address(self, address):
-        """Takes a value from an AddressField, returns a div class=address
-        with spans inside, containing the address field values.
-        """
-        addr = ''
-        if address:
-            # order of divs in output html
-            keys = ['address', 'city', 'district', 'state', 'zip', 'country']
-            addr = ''.join(["<span>%s</span>" % address.get(v) for v in keys
-                            if address.get(v, None)])
-        return "<div class='address'>%s</div>" % addr
 
     def getDimension(self):
         """ Returns the dimension of the report
@@ -1182,10 +1152,10 @@ class AnalysisRequestDigester:
             contact = contact[0].getObject() if contact else None
             cfullname = contact.getFullname() if contact else None
             cemail = contact.getEmailAddress() if contact else None
-            physical_address = self._format_address(
+            physical_address = _format_address(
                 contact.getPhysicalAddress()) if contact else ''
             postal_address =\
-                self._format_address(contact.getPostalAddress())\
+                    _format_address(contact.getPostalAddress())\
                 if contact else ''
             data = {'id': member.id,
                     'fullname': to_utf8(cfullname) if cfullname else to_utf8(
@@ -1226,7 +1196,7 @@ class AnalysisRequestDigester:
         lab_address = lab.getPostalAddress() \
                       or lab.getBillingAddress() \
                       or lab.getPhysicalAddress()
-        return self._format_address(lab_address)
+        return _format_address(lab_address)
 
     def _lab_data(self):
         portal = getToolByName(self.context, 'portal_url').getPortalObject()
@@ -1252,20 +1222,6 @@ class AnalysisRequestDigester:
                     'pubpref': contact.getPublicationPreference()}
         return data
 
-    def _client_address(self, ar):
-        client = ar.aq_parent
-        client_address = client.getPostalAddress()
-        if not client_address:
-            if not IAnalysisRequest.providedBy(ar):
-                return ""
-            # Data from the first contact
-            contact = ar.getContact()
-            if contact and contact.getBillingAddress():
-                client_address = contact.getBillingAddress()
-            elif contact and contact.getPhysicalAddress():
-                client_address = contact.getPhysicalAddress()
-        return self._format_address(client_address)
-
     def _client_data(self, ar):
         data = {}
         client = ar.aq_parent
@@ -1277,7 +1233,7 @@ class AnalysisRequestDigester:
             data['phone'] = to_utf8(client.getPhone())
             data['fax'] = to_utf8(client.getFax())
 
-            data['address'] = to_utf8(self._client_address(ar))
+            data['address'] = to_utf8(get_client_address(ar))
         return data
 
     def _specs_data(self, ar):
@@ -1559,3 +1515,35 @@ def EndRequestHandler(event):
     # If this commit() is not here, then the data does not appear to be
     # saved.  IEndRequest happens outside the transaction?
     transaction.commit()
+
+
+def get_client_address(context):
+    if context.portal_type == 'AnalysisRequest':
+        client = context.aq_parent
+    else:
+        client = context
+    client_address = client.getPostalAddress()
+    if not client_address:
+        ar = context
+        if not IAnalysisRequest.providedBy(ar):
+            return ""
+        # Data from the first contact
+        contact = ar.getContact()
+        if contact and contact.getBillingAddress():
+            client_address = contact.getBillingAddress()
+        elif contact and contact.getPhysicalAddress():
+            client_address = contact.getPhysicalAddress()
+    return _format_address(client_address)
+
+
+def _format_address(address):
+    """Takes a value from an AddressField, returns a div class=address
+    with spans inside, containing the address field values.
+    """
+    addr = ''
+    if address:
+        # order of divs in output html
+        keys = ['address', 'city', 'district', 'state', 'zip', 'country']
+        addr = ''.join(["<span>%s</span>" % address.get(v) for v in keys
+                        if address.get(v, None)])
+    return "<div class='address'>%s</div>" % addr

--- a/bika/lims/browser/analysisrequest/workflow.py
+++ b/bika/lims/browser/analysisrequest/workflow.py
@@ -654,7 +654,7 @@ class AnalysisRequestWorkflowAction(WorkflowAction):
             return
         url = self.context.absolute_url() + "/ar_add" + \
             "?ar_count={0}".format(len(objects)) + \
-            "&copy_from={0}".format(",".join(reversed(objects.keys())))
+            "&copy_from={0}".format(",".join(objects.keys()))
         self.request.response.redirect(url)
         return
 

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -145,7 +145,7 @@ class WorkflowAction:
 
         url = self.context.absolute_url() + "/ar_add" + \
             "?ar_count={0}".format(len(objects)) + \
-            "&copy_from={0}".format(",".join(reversed(objects.keys())))
+            "&copy_from={0}".format(",".join(objects.keys()))
 
         self.request.response.redirect(url)
         return

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -8,6 +8,8 @@
 import copy
 import json
 import traceback
+import collections
+
 from AccessControl import getSecurityManager
 from Acquisition import aq_inner
 
@@ -92,8 +94,9 @@ class WorkflowAction:
         form = self.request.form
         uc = getToolByName(self.context, 'uid_catalog')
 
-        selected_items = {}
-        for uid in form.get('uids', []):
+        uids = form.get("uids", [])
+        selected_items = collections.OrderedDict()
+        for uid in uids:
             try:
                 item = uc(UID = uid)[0].getObject()
             except:


### PR DESCRIPTION
Integration of:
- https://github.com/bikalims/bika.lims/pull/2130
- https://github.com/bikalims/bika.lims/pull/2233

**Current behavior before PR**

1. Infinite recursion if no Address details were found on the Client or Contact.
2. Selected items in listing tables were processed in random order. If a use selected ARs from the list and clicked the copy button, the ARs were listed in random order in the AR Add form (and of course created in this random order).

**Desired behavior after PR is merged**

1. Rendering succeeds w/o Address Details.
2. Selected items in listing views keep their order and copied ARs are processed in reversed order.
