### PR TITLE
The PDF generated for stickers doesn't have the right page dimensions

### DIFF
--- a/bika/lims/browser/templates/stickers/Code_128_1x48mm.css
+++ b/bika/lims/browser/templates/stickers/Code_128_1x48mm.css
@@ -1,27 +1,39 @@
+/*
+Sticker Dimensions: 48mm x 18mm
+Sticker margins: 8mm, 1mm
+*/
 .sticker {
+    margin:0 auto;
+    padding:1mm;
+    width: 46mm;    /* Total width  = 1 + 1 + 46 = 48mm */
+    height: 16mm;   /* Total height = 1 + 1 + 14 = 18mm */
     font-family: Helvetica, Arial;
     font-size:7pt;
-    /* Total width: 46mm + 2x1mm = 48mm */
-    padding:1mm; width: 46mm;
-}
-.sticker .sample-id {
-    height: 5mm;
     text-align:center;
-    margin-bottom: 5px;
 }
-.sticker .analysisrequest-info table,
-.sticker .sampling-date-info table {
-    border-collapse:collapse;
-    margin: 1px 1px 1px 1px;
+
+.sticker .barcode {
+    margin: 0 !important;
+    margin: 0 auto;
+    padding: 1mm 0 !important;
+    text-align:center;
+}
+
+.analysisrequest-info table {
     width:100%;
-}
-.sticker .analysisrequest-info table td,
-.sticker .sampling-date-info table td {
-    border:none;
-}
-.barcode {
-    margin:0 auto;
 }
 .client-sample-id {
     text-align:center;
+}
+
+@media print {
+    @page {
+        size:  48mm 18mm !important;
+        margin: 0mm !important;
+    }
+    html, body {
+        width: 48mm !important;
+        height: 18mm !important;
+        margin: 0mm !important;
+    }
 }

--- a/bika/lims/browser/templates/stickers/Code_128_1x72mm.css
+++ b/bika/lims/browser/templates/stickers/Code_128_1x72mm.css
@@ -1,30 +1,49 @@
+/*
+Sticker Dimensions: 72mm x 40mm
+Sticker margins: 1mm, 1mm
+*/
 .sticker {
+    margin:0 auto;
+    padding:1mm;
+    width: 70mm;    /* Total width  = 1 + 1 + 70 = 72mm */
+    height: 38mm;   /* Total height = 1 + 1 + 38 = 40mm */
     font-family: Helvetica, Arial;
-    font-size:6pt;
-    /* Total width: 70mm + 2x1mm = 72mm */
-    padding:1mm; width: 70mm;
-}
-.sticker .sample-id {
-    height: 5mm;
+    font-size:7pt;
     text-align:center;
-    margin-bottom: 5px;
 }
-table {
+
+.sticker .barcode {
+    margin: 0 !important;
+    margin: 0 auto;
+    padding: 1mm 0 !important;
+    text-align:center;
+}
+
+table.info-container {
+    height:38mm;
     border-collapse:collapse;
-    margin: 1px 1px 1px 1px;
     font-size: 6pt;
     width:100%;
 }
-th {
+table.info-container th {
     text-align: left;
     text-transform: none;
     border: 1pt solid #888;
     padding:0.5mm;
 }
-td {
+table.info-container td {
     border: 1pt solid #888;
     padding:0.5mm;
 }
-.barcode {
-    margin:0 auto;
+
+@media print {
+    @page {
+        size:  72mm 40mm !important;
+        margin: 0mm !important;
+    }
+    html, body {
+        width: 72mm !important;
+        height: 40mm !important;
+        margin: 0mm !important;
+    }
 }

--- a/bika/lims/browser/templates/stickers/Code_128_1x72mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_128_1x72mm.pt
@@ -45,7 +45,8 @@
     smart_id          python:part.getId() if show_partitions else sample.getId();
     hazardous         python:sample.getSampleType().getHazardous();">
 
-    <table cellpadding="0" cellspacing="0">
+
+    <table cellpadding="0" cellspacing="0" class="info-container">
         <thead>
             <tr>
                 <th i18n:translate="">Sample ID</th>

--- a/bika/lims/browser/templates/stickers/Code_39_1x54mm.css
+++ b/bika/lims/browser/templates/stickers/Code_39_1x54mm.css
@@ -1,27 +1,39 @@
+/*
+Sticker Dimensions: 54mm x 18mm
+Sticker margins: 1mm, 1mm
+*/
 .sticker {
+    margin:0 auto;
+    padding:1mm;
+    width: 52mm;    /* Total width  = 1 + 1 + 52 = 54mm */
+    height: 16mm;   /* Total height = 1 + 1 + 16 = 18mm */
     font-family: Helvetica, Arial;
     font-size:7pt;
-    /* Total width: 52mm + 2x1mm = 54mm */
-    padding:1mm; width: 52mm;
-}
-.sticker .sample-id {
-    height: 5mm;
     text-align:center;
-    margin-bottom: 5px;
 }
-.sticker .analysisrequest-info table,
-.sticker .sampling-date-info table {
-    border-collapse:collapse;
-    margin: 1px 1px 1px 1px;
+
+.sticker .barcode {
+    margin: 0 !important;
+    margin: 0 auto;
+    padding: 1mm 0 !important;
+    text-align:center;
+}
+
+.analysisrequest-info table {
     width:100%;
-}
-.sticker .analysisrequest-info table td,
-.sticker .sampling-date-info table td {
-    border:none;
-}
-.barcode {
-    margin:0 auto;
 }
 .client-sample-id {
     text-align:center;
+}
+
+@media print {
+    @page {
+        size:  54mm 18mm !important;
+        margin: 0mm !important;
+    }
+    html, body {
+        width: 54mm !important;
+        height: 18mm !important;
+        margin: 0mm !important;
+    }
 }

--- a/bika/lims/browser/templates/stickers/Code_39_1x72mm.css
+++ b/bika/lims/browser/templates/stickers/Code_39_1x72mm.css
@@ -1,30 +1,52 @@
+/*
+Sticker Dimensions: 72mm x 40mm
+Sticker margins: 1mm, 1mm
+*/
 .sticker {
+    margin:0 auto;
+    padding:1mm;
+    width: 70mm;    /* Total width  = 1 + 1 + 70 = 72mm */
+    height: 38mm;   /* Total height = 1 + 1 + 38 = 40mm */
     font-family: Helvetica, Arial;
-    font-size:6pt;
-    /* Total width: 70mm + 2x1mm = 72mm */
-    padding:1mm; width: 70mm;
-}
-.sticker .sample-id {
-    height: 5mm;
+    font-size:7pt;
     text-align:center;
-    margin-bottom: 5px;
 }
-table {
+
+.sticker .barcode {
+    margin: 0 !important;
+    margin: 0 auto;
+    padding: 1mm 0 !important;
+    text-align:center;
+}
+
+table.info-container {
+    height:38mm;
     border-collapse:collapse;
-    margin: 1px 1px 1px 1px;
     font-size: 6pt;
     width:100%;
 }
-th {
+table.info-container th {
     text-align: left;
     text-transform: none;
     border: 1pt solid #888;
     padding:0.5mm;
 }
-td {
+table.info-container tr {
+    border-collapse: separate;
+}
+table.info-container td {
     border: 1pt solid #888;
     padding:0.5mm;
 }
-.barcode {
-    margin:0 auto;
+
+@media print {
+    @page {
+        size:  72mm 40mm !important;
+        margin: 0mm !important;
+    }
+    html, body {
+        width: 72mm !important;
+        height: 40mm !important;
+        margin: 0mm !important;
+    }
 }

--- a/bika/lims/browser/templates/stickers/Code_39_1x72mm.pt
+++ b/bika/lims/browser/templates/stickers/Code_39_1x72mm.pt
@@ -45,7 +45,7 @@
     smart_id          python:part.getId() if show_partitions else sample.getId();
     hazardous         python:sample.getSampleType().getHazardous();">
 
-    <table cellpadding="0" cellspacing="0">
+    <table cellpadding="0" cellspacing="0" class="info-container">
         <thead>
             <tr>
                 <th i18n:translate="">Sample ID</th>

--- a/bika/lims/browser/templates/stickers/Code_93_2dx38mm.css
+++ b/bika/lims/browser/templates/stickers/Code_93_2dx38mm.css
@@ -1,44 +1,43 @@
+/*
+Two stickers horizontaly aligned
+Sticker Dimensions: (40mm x 21mm) x 2
+Sticker margins: (1mm, 1mm) x 2
+*/
 .sticker {
+    margin:0 auto;
+    padding:0mm;    /* The horizontal padding is done by sticker-*-separator */
+    width: 86mm;    /* Total width  = 1 + 40 + 1 + 2 + 1 + 40 + 1 = 86mm */
+    height: 19mm;   /* Total height = 1 + 1 + 19 = 21mm */
+    max-width:86mm;
+    max-height: 19mm;
     font-family: Helvetica, Arial;
     font-size:7pt;
-    /* Total width: 1.5mm + 38mm + 1.5mm + 1.5mm + 38mm + 1.5mm = 82mm */
-    width: 82mm;
-    min-width:82mm;
-    max-width:82mm;
-    /* Total height: 1.5mm + 18mm + 1.5mm = 21mm */
-    height:21mm;
-    min-height:21mm;
-    max-height:21mm;
-
+    text-align:center;
     overflow:hidden;
-    border-bottom:none;
+    background-color:#dcdcdc;
 }
+
+/* Each sticker row contains 2 stickers */
 .sticker table.stickers-row {
     width:100%;
     border-collapse: separate;
-    background-color:#f5f5f5;
-}
-.sticker table.stickers-row td.sticker-vertical-separator {
-    height:1.5mm;
-    min-height:1.5mm;
-    max-height:1.5mm;
     background-color:#dcdcdc;
 }
-.sticker table.stickers-row td.sticker-horizontal-separator {
-    width:1.5mm;
-    min-width:1.5mm;
-    max-width:1.5mm;
-    background-color:#dcdcdc;
-}
+
+/** Each sticker is rendered inside a sticker-cell */
 .sticker table.stickers-row td.sticker-cell {
     background-color:#fff;
     width:38mm;
-    height:18mm;
+    height:17mm;
     max-width:38mm;
-    max-height:18mm;
+    max-height:19mm;
+    padding:0mm;
 }
-.sticker .analysisrequest-info table td.sample-type {
-    width:100%;
+.sticker table.stickers-row td.sticker-horizontal-separator {
+    width:0.5mm;
+    min-width:0.5mm;
+    max-width:0.5mm;
+    background-color:#dcdcdc;
 }
 .sticker .analysisrequest-info table,
 .sticker .sampling-date-info table {
@@ -51,9 +50,26 @@
     padding-left:2mm;
 }
 
-.barcode {
-    margin:0 auto;
-}
-.client-sample-id {
+.sticker .barcode {
+    margin: 0 !important;
+    margin: 0 auto;
+    padding: 0mm 0 !important;
     text-align:center;
+}
+
+@media print {
+    @page {
+        size:  86mm 21mm !important;
+        margin: 0mm !important;
+    }
+    html, body {
+        width: 86mm !important;
+        height: 21mm !important;
+        margin: 0mm !important;
+    }
+    .sticker,
+    .sticker table.stickers-row,
+    .sticker table.stickers-row td.sticker-horizontal-separator{
+        background-color: #fff;
+    }
 }

--- a/bika/lims/browser/templates/stickers/Code_93_2x38mm.css
+++ b/bika/lims/browser/templates/stickers/Code_93_2x38mm.css
@@ -1,44 +1,43 @@
+/*
+Two stickers horizontaly aligned
+Sticker Dimensions: (40mm x 21mm) x 2
+Sticker margins: (1mm, 1mm) x 2
+*/
 .sticker {
+    margin:0 auto;
+    padding:0mm;    /* The horizontal padding is done by sticker-*-separator */
+    width: 86mm;    /* Total width  = 1 + 40 + 1 + 2 + 1 + 40 + 1 = 86mm */
+    height: 19mm;   /* Total height = 1 + 1 + 19 = 21mm */
+    max-width:86mm;
+    max-height: 19mm;
     font-family: Helvetica, Arial;
     font-size:7pt;
-    /* Total width: 1.5mm + 38mm + 1.5mm + 1.5mm + 38mm + 1.5mm = 82mm */
-    width: 82mm;
-    min-width:82mm;
-    max-width:82mm;
-    /* Total height: 1.5mm + 18mm + 1.5mm = 21mm */
-    height:21mm;
-    min-height:21mm;
-    max-height:21mm;
-
+    text-align:center;
     overflow:hidden;
-    border-bottom:none;
+    background-color:#dcdcdc;
 }
+
+/* Each sticker row contains 2 stickers */
 .sticker table.stickers-row {
     width:100%;
     border-collapse: separate;
-    background-color:#f5f5f5;
-}
-.sticker table.stickers-row td.sticker-vertical-separator {
-    height:1.5mm;
-    min-height:1.5mm;
-    max-height:1.5mm;
     background-color:#dcdcdc;
 }
-.sticker table.stickers-row td.sticker-horizontal-separator {
-    width:1.5mm;
-    min-width:1.5mm;
-    max-width:1.5mm;
-    background-color:#dcdcdc;
-}
+
+/** Each sticker is rendered inside a sticker-cell */
 .sticker table.stickers-row td.sticker-cell {
     background-color:#fff;
     width:38mm;
-    height:18mm;
+    height:17mm;
     max-width:38mm;
-    max-height:18mm;
+    max-height:19mm;
+    padding:0mm;
 }
-.sticker .analysisrequest-info table td.sample-type {
-    width:100%;
+.sticker table.stickers-row td.sticker-horizontal-separator {
+    width:0.5mm;
+    min-width:0.5mm;
+    max-width:0.5mm;
+    background-color:#dcdcdc;
 }
 .sticker .analysisrequest-info table,
 .sticker .sampling-date-info table {
@@ -51,9 +50,26 @@
     padding-left:2mm;
 }
 
-.barcode {
-    margin:0 auto;
-}
-.client-sample-id {
+.sticker .barcode {
+    margin: 0 !important;
+    margin: 0 auto;
+    padding: 0mm 0 !important;
     text-align:center;
+}
+
+@media print {
+    @page {
+        size:  86mm 21mm !important;
+        margin: 0mm !important;
+    }
+    html, body {
+        width: 86mm !important;
+        height: 21mm !important;
+        margin: 0mm !important;
+    }
+    .sticker,
+    .sticker table.stickers-row,
+    .sticker table.stickers-row td.sticker-horizontal-separator{
+        background-color: #fff;
+    }
 }

--- a/bika/lims/browser/templates/stickers/QR_1x14mmx39mm.css
+++ b/bika/lims/browser/templates/stickers/QR_1x14mmx39mm.css
@@ -1,12 +1,32 @@
-/*  Heights */
+/*
+Sticker Dimensions: 14mm x 39mm
+Sticker margins: 8mm, 1mm
+*/
 .sticker {
-    padding-top:       8mm;
-    padding-bottom:    8mm;
-    height:           21mm; /* Total height =  37mm */
-    width:            14mm;
+    margin:0 auto;
+    padding:8mm 1mm;
+    width: 12mm;    /* Total width  = 1 + 1 + 12 = 14mm */
+    height: 23mm;   /* Total height = 8 + 8 + 23 = 37mm */
     font-family: Helvetica, Arial;
     font-size:6pt;
     text-align:center;
 }
-div.requestid { padding-top: 2mm; line-height: 4mm;}
-div.clientsampleid { line-height: 4mm;}
+
+.sticker .barcode {
+    margin: 0 !important;
+    margin: 0 auto;
+    padding: 0 !important;
+    text-align:center;
+}
+
+@media print {
+    @page {
+        size:  14mm 39mm !important;
+        margin: 0mm !important;
+    }
+    html, body {
+        height: 39mm !important;
+        width: 14mm !important;
+        margin: 0mm !important;
+    }
+}


### PR DESCRIPTION
Stickers did not have the correct dimensions set for the page, so the generated pdf was not correctly generated. With this PR, each sticker is rendered within a pdf page that have the correct dimensions.

Two examples:
- [code128x1x48mm.pdf](https://github.com/senaite/bika.lims/files/1415543/code128x1x48mm.pdf)
- [code128x1x72mm.pdf](https://github.com/senaite/bika.lims/files/1415546/code128x1x72mm.pdf)
 
Note each page of the pdf document has the correct dimensions and each label is printed on a single page
