### PR TITLE
Several small WS print fixtures

### DIFF
--- a/bika/lims/browser/worksheet/templates/print.pt
+++ b/bika/lims/browser/worksheet/templates/print.pt
@@ -7,12 +7,12 @@
       xmlns:metal="http://xml.zope.org/namespaces/metal"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
       tal:attributes="lang default_language|default;
-             xml:lang default_language|default;"
+                      xml:lang default_language|default;"
       i18n:domain="bika"
       tal:define="portal_state context/@@plone_portal_state;
-             portal_url portal_state/portal_url;
-             plone_view context/@@plone;
-             portal portal_state/portal;">
+                  portal_url portal_state/portal_url;
+                  plone_view context/@@plone;
+                  portal portal_state/portal;">
   <head>
     <div tal:replace="structure provider:plone.resourceregistries.scripts" />
     <style>
@@ -140,7 +140,7 @@
           </select>
         </div>
         <div id='buttons'>
-          <input type="button" id='cancel_button' i18n:attributes="value" value="Cancel"/>&nbsp;&nbsp;
+          <input type="button" id='cancel_button' i18n:attributes="value" value="Cancel"/>
           <input type="button" id='print_button' i18n:attributes="value" value="Print"/>
         </div>
       </div>

--- a/bika/lims/browser/worksheet/templates/print.pt
+++ b/bika/lims/browser/worksheet/templates/print.pt
@@ -140,8 +140,8 @@
           </select>
         </div>
         <div id='buttons'>
-          <input type="button" id='cancel_button' i18n:translate="value" value="Cancel"/>&nbsp;&nbsp;
-          <input type="button" id='print_button' i18n:translate="value" value="Print"/>
+          <input type="button" id='cancel_button' i18n:attributes="value" value="Cancel"/>&nbsp;&nbsp;
+          <input type="button" id='print_button' i18n:attributes="value" value="Print"/>
         </div>
       </div>
       <style id='report-style' tal:content='structure python:view.getCSS()'></style>

--- a/bika/lims/browser/worksheet/templates/print/ar_by_column.pt
+++ b/bika/lims/browser/worksheet/templates/print/ar_by_column.pt
@@ -11,11 +11,13 @@
     See README.txt for further details about the dict structure
 
 -->
-<tal:print tal:define="worksheet       python:view.getWorksheet();
-                       laboratory      worksheet/laboratory;
-                       portal          worksheet/portal;
-                       ars             worksheet/ars;
-                       anstitles       worksheet/analyses_titles;">
+<tal:print
+  i18n:domain="bika"
+  tal:define="worksheet       python:view.getWorksheet();
+              laboratory      worksheet/laboratory;
+              portal          worksheet/portal;
+              ars             worksheet/ars;
+              anstitles       worksheet/analyses_titles;">
 
   <div id="header">
     <div class='barcode-container'>

--- a/bika/lims/browser/worksheet/templates/print/ar_by_row.pt
+++ b/bika/lims/browser/worksheet/templates/print/ar_by_row.pt
@@ -11,11 +11,13 @@
     See README.txt for further details about the dict structure
 
 -->
-<tal:print tal:define="worksheet       python:view.getWorksheet();
-                       laboratory      worksheet/laboratory;
-                       portal          worksheet/portal;
-                       ars             worksheet/ars;
-                       anstitles       worksheet/analyses_titles;">
+<tal:print
+  i18n:domain="bika"
+  tal:define="worksheet       python:view.getWorksheet();
+              laboratory      worksheet/laboratory;
+              portal          worksheet/portal;
+              ars             worksheet/ars;
+              anstitles       worksheet/analyses_titles;">
 
   <div id="header">
     <div class='barcode-container'>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Several minor fixes for WS print template

## Current behavior before PR

- WS print templates did not have a proper `i18n` domain
- WS print template had wront `i18n` attribute set, which caused the value to be displayed next to the buttons 

## Desired behavior after PR is merged

WS print templates display nice and clean

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html