### PR TITLE
Show action buttons when sorting by column in listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ LIMS-1504: Calculation formula test widgets
 
 **Fixed**
 
+- #330 Show action buttons when shorting by column in listings
 - #280 Integration of PR-2271. Setting 2 or more CCContacts in AR view produces a Traceback on Save
 - #281 Integration of PR-2269. Show the Unit in Manage Analyses View
 - #282 Integration of PR-2252. Traceback if the title contains braces on content creation

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -142,7 +142,8 @@ function BikaListingTableView() {
 			var options = {
 				target: $(this).parents("table"),
 				replaceTarget: true,
-				data: form.formToArray()
+				data: form.formToArray(),
+				success: load_transitions
 			}
 			form.ajaxSubmit(options)
 			$("[name='table_only']").remove()


### PR DESCRIPTION
Fixes https://github.com/senaite/bika.lims/issues/305

**Problem**
When the user clicks to a sortable header, the system fires an ajaxsubmit that returns a new html table with the items sorted in accordance with the header clicked. The same ajaxsubmit (thanks to `replaceTarget` option), replaces the current table with the new one:

https://github.com/senaite/bika.lims/blob/696a1047180bbac39ecc0f0a58e145f1bb2ba2a1/bika/lims/browser/js/bika.lims.bikalisting.js#L138-L147

Because of the dynamic loading of transitions https://github.com/senaite/bika.lims/pull/150 , the list returned by the ajaxsubmit does not include the available transitions for each item, so only transitions defined in `custom_actions` are displayed. Since in Worksheet's add Analyses view there is no `custom_actions` defined, no action buttons are displayed at the bottom of the list.

**Resolution**
Added a `success` option in the ajaxSubmit, so the function `load_transitions`, that contains the logic responsible of loading allowed transitions for the items listed (and, therefore, the action buttons list rendered correctly) is fired once the table is replaced.