### PR TITLE
Display analyses sorted by sortkey in results report 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Changed**
 
+- #331 Sort analyses lists by sortkey as default
 Issue-1999: Allow external Python library functions to be used in Calculation Formulas
 LIMS-1504: Calculation formula test widgets
 #2154: Feature/new ar add form

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Changed**
 
+- #333 Sort analyses by sortkey in results report
 - #331 Sort analyses lists by sortkey as default
 Issue-1999: Allow external Python library functions to be used in Calculation Formulas
 LIMS-1504: Calculation formula test widgets

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -44,7 +44,7 @@ class AnalysesView(BikaListingView):
         self.catalog = CATALOG_ANALYSIS_LISTING
         self.contentFilter = dict(kwargs)
         self.contentFilter['portal_type'] = 'Analysis'
-        self.contentFilter['sort_on'] = 'created'
+        self.contentFilter['sort_on'] = 'sortable_title'
         self.contentFilter['sort_order'] = 'ascending'
         self.sort_order = 'ascending'
         self.context_actions = {}
@@ -82,6 +82,7 @@ class AnalysesView(BikaListingView):
             'Service': {
                 'title': _('Analysis'),
                 'attr': 'Title',
+                'index': 'sortable_title',
                 'sortable': False},
             'Partition': {
                 'title': _("Partition"),

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -26,7 +26,9 @@ from Products.CMFPlone.utils import _createObjectByType, safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import POINTS_OF_CAPTURE, bikaMessageFactory as _, t
 from bika.lims import logger
+from bika.lims.api import get_tool
 from bika.lims.browser import BrowserView, ulocalized_time
+from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.idserver import renameAfterCreation
 from bika.lims.interfaces import IAnalysisRequest, IResultOutOfRange
 from bika.lims.interfaces.field import IUIDReferenceField
@@ -1261,9 +1263,13 @@ class AnalysisRequestDigester:
         batch = ar.getBatch()
         workflow = getToolByName(self.context, 'portal_workflow')
         showhidden = self.isHiddenAnalysesVisible()
-        for an in ar.getAnalyses(
-                full_objects=True, review_state=analysis_states):
 
+        catalog = get_tool(CATALOG_ANALYSIS_LISTING)
+        brains = catalog({'getAnalysisRequestUID': ar.UID(),
+                          'review_state': analysis_states,
+                          'sort_on': 'sortable_title'})
+        for brain in brains:
+            an = brain.getObject()
             # Omit hidden analyses?
             if not showhidden and an.getHidden():
                 continue

--- a/bika/lims/browser/worksheet/views/analyses.py
+++ b/bika/lims/browser/worksheet/views/analyses.py
@@ -23,7 +23,9 @@ class AnalysesView(BaseView):
         self.instrument = None
         self.contentFilter = {
             'getWorksheetUID': context.UID(),
+            'sort_on': 'sortable_title'
         }
+        self.sort_on = 'sortable_title'
         self.icon = self.portal_url + "/++resource++bika.lims.images/worksheet_big.png"
         self.allow_edit = True
         self.show_categories = False
@@ -156,12 +158,6 @@ class AnalysesView(BaseView):
                     'select_column': '',
                     }
                 items.append(item)
-
-        items = sorted(items, key = itemgetter('Service'))
-        try:
-            items = sorted(items, key = itemgetter('Pos'))
-        except:
-            pass
 
         slot_items = {} # pos:[item_nrs]
         for x in range(len(items)):

--- a/bika/lims/browser/worksheet/views/analyses.py
+++ b/bika/lims/browser/worksheet/views/analyses.py
@@ -159,6 +159,8 @@ class AnalysesView(BaseView):
                     }
                 items.append(item)
 
+        items = sorted(items, key=itemgetter('Pos'))
+
         slot_items = {} # pos:[item_nrs]
         for x in range(len(items)):
             p = items[x]['Pos']

--- a/bika/lims/catalog/analysis_catalog.py
+++ b/bika/lims/catalog/analysis_catalog.py
@@ -19,6 +19,7 @@ from bika.lims.catalog.catalog_basic_template import BASE_CATALOG_COLUMNS
 CATALOG_ANALYSIS_LISTING = 'bika_analysis_catalog'
 # Defining the indexes for this catalog
 _indexes_dict = {
+    'sortable_title': 'FieldIndex',
     'worksheetanalysis_review_state': 'FieldIndex',
     'cancellation_state': 'FieldIndex',
     'getParentUID': 'FieldIndex',

--- a/bika/lims/catalog/indexers/baseanalysis.py
+++ b/bika/lims/catalog/indexers/baseanalysis.py
@@ -1,9 +1,9 @@
-from bika.lims.interfaces import IAnalysisService
-from plone.indexer import indexer
 from Products.CMFPlone.CatalogTool import sortable_title as _sortable_title
+from bika.lims.interfaces import IBaseAnalysis
+from plone.indexer import indexer
 
 
-@indexer(IAnalysisService)
+@indexer(IBaseAnalysis)
 def sortable_title(instance):
     sort_key = instance.getSortKey()
     if sort_key is None:

--- a/bika/lims/catalog/indexers/configure.zcml
+++ b/bika/lims/catalog/indexers/configure.zcml
@@ -3,6 +3,6 @@
     i18n_domain="bika">
 
   <adapter name="sortable_title" factory=".analysiscategory.sortable_title"/>
-  <adapter name="sortable_title" factory=".analysisservice.sortable_title"/>
+  <adapter name="sortable_title" factory=".baseanalysis.sortable_title"/>
 
 </configure>

--- a/bika/lims/content/abstractbaseanalysis.py
+++ b/bika/lims/content/abstractbaseanalysis.py
@@ -16,15 +16,16 @@ from Products.Archetypes.Widget import BooleanWidget, DecimalWidget, \
 from Products.Archetypes.utils import DisplayList, IntDisplayList
 from Products.CMFCore.utils import getToolByName
 from bika.lims import bikaMessageFactory as _
-from bika.lims.browser.fields import DurationField, InterimFieldsField, \
-    UIDReferenceField
+from bika.lims.browser.fields import DurationField, UIDReferenceField
 from bika.lims.browser.widgets.durationwidget import DurationWidget
 from bika.lims.browser.widgets.recordswidget import RecordsWidget
 from bika.lims.browser.widgets.referencewidget import ReferenceWidget
 from bika.lims.browser.widgets.uidselectionwidget import UIDSelectionWidget
 from bika.lims.config import ATTACHMENT_OPTIONS, SERVICE_POINT_OF_CAPTURE
 from bika.lims.content.bikaschema import BikaSchema
+from bika.lims.interfaces import IBaseAnalysis
 from bika.lims.utils import to_utf8 as _c
+from zope.interface import implements
 
 # Anywhere that there just isn't space for unpredictably long names,
 # this value will be used instead.  It's set on the AnalysisService,
@@ -703,6 +704,7 @@ schema['title']._validationLayer()
 
 
 class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
+    implements(IBaseAnalysis)
     security = ClassSecurityInfo()
     schema = schema
     displayContentsTab = False

--- a/bika/lims/interfaces/__init__.py
+++ b/bika/lims/interfaces/__init__.py
@@ -206,6 +206,9 @@ class IAnalysisCategories(Interface):
 
     ""
 
+class IBaseAnalysis(Interface):
+    ""
+
 
 class IAnalysisService(Interface):
 

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1.0.0</version>
+  <version>1.1.0</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/upgrade/README.rst
+++ b/bika/lims/upgrade/README.rst
@@ -1,0 +1,13 @@
+The following are the rules to follow when adding new upgrade steps:
+
+1) If the upgrade step is required by a contribution to be merged into master,
+   increase the last number of the version.
+   eg.: from v01_00_000.py to v01_00_001.py
+
+2) If the upgrade step is required by a contribution that will be merged into
+   develop branch (in most cases, big changes in code, architectural, etc.),
+   increase the second number of the version.
+   eg.: from v01_00_000.py to v01_01_000.py
+
+Also remember to update the version number in bika/lims/profiles/metadata.xml
+and bika/lims/upgrade/configure.zcml

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -17,4 +17,11 @@
        handler="bika.lims.upgrade.v01_00_000.upgrade"
        profile="bika.lims:default"/>
 
+ <genericsetup:upgradeStep
+       title="Upgrade to Bika LIMS Evo 1.1.0"
+       source="1.0.0"
+       destination="1.1.0"
+       handler="bika.lims.upgrade.v01_01_000.upgrade"
+       profile="bika.lims:default"/>
+
 </configure>

--- a/bika/lims/upgrade/v01_01_000.py
+++ b/bika/lims/upgrade/v01_01_000.py
@@ -1,0 +1,45 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from bika.lims import logger
+from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.config import PROJECTNAME as product
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+
+version = '1.1.0'
+profile = 'profile-{0}:default'.format(product)
+
+
+@upgradestep(product, version)
+def upgrade(tool):
+    portal = aq_parent(aq_inner(tool))
+    setup = portal.portal_setup
+    ut = UpgradeUtils(portal)
+    ver_from = ut.getInstalledVersion(product)
+
+    if ut.isOlderVersion(product, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+            product, ver_from, version))
+        # The currently installed version is more recent than the target
+        # version of this upgradestep
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
+
+    # Required because of a mismatch between the view and workflow states
+    # selector in Analysis Services view. See @93109be
+    setup.runImportStepFromProfile('profile-bika.lims:default', 'typeinfo')
+
+    # Remove indexes no longer used as per @daf57e3 and PR#307
+    ut.delIndexAndColumn('bika_setup_catalog', 'getSortKey')
+    ut.delIndexAndColumn('bika_setup_catalog', 'sortKey')
+
+    # Add sortable_title index in analyses catalog, so analyses get sorted
+    # automatically based on the same rules as Analysis Services do (PR#307):
+    #   sortkey + title ascending
+    ut.addIndex(CATALOG_ANALYSIS_LISTING, 'sortable_title', 'FieldIndex')
+    ut.refreshCatalogs()
+
+    # Do nothing, we just only want the profile version to be 1.0.0
+    logger.info("{0} upgraded to version {1}".format(product, version))
+    return True


### PR DESCRIPTION
Fixes https://github.com/senaite/bika.lims/issues/290

As per https://github.com/senaite/bika.lims/pull/331 (**to be reviewed/accepted first**), all analyses listings are sorted now by sort key. With this PR, the analyses are displayed accordingly in results report