### PR TITLE
Keep laboratory name when reinstalling 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,7 @@ Changelog
 - #312 Worksheet: "Print" does not display/print partial results
 - #314 'SamplingDate' and 'DateSampled' fields of AR and Sample objects don't behave properly.
 - #321 Stickers on listing plus autoprint generates PDF, PR-2158
-
+- #327 Keep Laboratory name when reinstalling
 
 1.0.0 (2017-10-13)
 ------------------

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -30,12 +30,11 @@ class BikaGenerator(object):
 
     def setupPortalContent(self, portal):
         """ Setup Bika site structure """
-
         self.fix_frontpage_permissions(portal)
         self.remove_default_content(portal)
         self.reindex_structure(portal)
 
-        portal.bika_setup.laboratory.edit(title=_('Laboratory'))
+
         portal.bika_setup.laboratory.unmarkCreationFlag()
         portal.bika_setup.laboratory.reindexObject()
 

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -34,7 +34,6 @@ class BikaGenerator(object):
         self.remove_default_content(portal)
         self.reindex_structure(portal)
 
-
         portal.bika_setup.laboratory.unmarkCreationFlag()
         portal.bika_setup.laboratory.reindexObject()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Linked issue: #327
 
## Current behavior before PR
When reinstalling ```Bika LIMS Evo``` the laboratory name is set to ```Laboratory```.

## Desired behavior after  PR is merged
The laboratory name stays on the entered value.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html