### PR TITLE
Temporary fix. Error when adding reference analysis in a Worksheet

### DIFF
--- a/bika/lims/content/referenceanalysis.py
+++ b/bika/lims/content/referenceanalysis.py
@@ -151,6 +151,30 @@ class ReferenceAnalysis(AbstractAnalysis):
         """
         return []
 
+    @deprecated("[1710] Reference Analyses do not support Interims")
+    def setInterimFields(self, interims=None , **kwargs):
+        pass
+
+    @deprecated("[1710] Reference Analyses do not support Interims")
+    def getInterimFields(self):
+        return []
+
+    @deprecated("[1710] Reference Analyses do not support Calculations")
+    def setCalculation(self, calculation=None, **kwargs):
+        pass
+
+    @deprecated("[1710] Reference Analyses do not support Calculations")
+    def getCalculation(self):
+        return None
+
+    @deprecated("[1710] Reference Analyses do not support Calculations")
+    def getCalculationTitle(self):
+        return None
+
+    @deprecated("[1710] Reference Analyses do not support Calculations")
+    def getCalculationUID(self):
+        return None
+
     @deprecated('[1705] Use bika.lims.workflow.analysis.events.after_submit')
     @security.public
     def workflow_script_submit(self):


### PR DESCRIPTION
When adding a reference analysis (either control or blank) into a worksheet, the following error is raised:
```
Traceback (innermost last):

    Module ZPublisher.Publish, line 138, in publish
    Module ZPublisher.mapply, line 77, in mapply
    Module ZPublisher.Publish, line 48, in call_object
    Module bika.lims.browser.worksheet.views.add_blank, line 56, in __call__
    Module bika.lims.content.worksheet, line 305, in addReferences
    Module bika.lims.content.referencesample, line 360, in addReferenceAnalysis

AttributeError: setInterimFields 
```
`InterimFields` Schema's field was recently removed from `AbstractBaseAnalysis` here https://github.com/senaite/bika.lims/commit/5a2a0948ed65409c001011daa29710d2b9345db5, but there are still some places in the code that either `setInterimFields` or `getInterimFields` are used. @rockfruit, this is a good example of why `deprecated` decorator is useful. With this Pull Request, the problem is solved and all works as expected (reference analyses do not support calculations or interims), but we will need to go into further details when we remove these `deprecated` functions.