### PR TITLE
Analyses sorted by priority in Add Analyses view and preserve AR order when adding into Worksheet

### DIFF
--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -38,9 +38,11 @@ class AddAnalysesView(BikaListingView):
         self.context_actions = {}
         # initial review state for first form display of the worksheet
         # add_analyses search view - first batch of analyses, latest first.
+        self.sort_on = 'Priority'
         self.contentFilter = {'portal_type': 'Analysis',
                               'review_state':'sample_received',
                               'worksheetanalysis_review_state':'unassigned',
+                              'sort_on': 'getPrioritySortkey',
                               'cancellation_state':'active'}
         self.base_url = self.context.absolute_url()
         self.view_url = self.base_url + "/add_analyses"

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -483,13 +483,14 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
         :return: string used for sorting
         """
         analysis_request = self.getRequest()
-        if analysis_request:
-            ar_sort_key = analysis_request.getPrioritySortkey()
-            ar_id = analysis_request.getId().lower()
-            title = sortable_title(self)
-            if callable(title):
-                title = title()
-            return '{}.{}.{}'.format(ar_sort_key, ar_id, title)
+        if analysis_request is None:
+            return None
+        ar_sort_key = analysis_request.getPrioritySortkey()
+        ar_id = analysis_request.getId().lower()
+        title = sortable_title(self)
+        if callable(title):
+            title = title()
+        return '{}.{}.{}'.format(ar_sort_key, ar_id, title)
 
 
     @security.public

--- a/bika/lims/content/abstractroutineanalysis.py
+++ b/bika/lims/content/abstractroutineanalysis.py
@@ -16,6 +16,7 @@ from bika.lims import deprecated
 from bika.lims.browser.fields import HistoryAwareReferenceField, \
     InterimFieldsField, UIDReferenceField
 from bika.lims.browser.widgets import DecimalWidget, RecordsWidget
+from bika.lims.catalog.indexers.baseanalysis import sortable_title
 from bika.lims.content.abstractanalysis import AbstractAnalysis
 from bika.lims.content.abstractanalysis import schema
 from bika.lims.content.reflexrule import doReflexRuleAction
@@ -477,13 +478,19 @@ class AbstractRoutineAnalysis(AbstractAnalysis):
     @security.public
     def getPrioritySortkey(self):
         """
-        Returns the key that will be used to sort the current Analysis
-        Delegates to getPrioritySortKey function from the AnalysisRequest
+        Returns the key that will be used to sort the current Analysis, from
+        most prioritary to less prioritary.
         :return: string used for sorting
         """
         analysis_request = self.getRequest()
         if analysis_request:
-            return analysis_request.getPrioritySortkey()
+            ar_sort_key = analysis_request.getPrioritySortkey()
+            ar_id = analysis_request.getId().lower()
+            title = sortable_title(self)
+            if callable(title):
+                title = title()
+            return '{}.{}.{}'.format(ar_sort_key, ar_id, title)
+
 
     @security.public
     def getHidden(self):

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -24,4 +24,11 @@
        handler="bika.lims.upgrade.v01_01_000.upgrade"
        profile="bika.lims:default"/>
 
+ <genericsetup:upgradeStep
+       title="Upgrade to Bika LIMS Evo 1.1.1"
+       source="1.1.0"
+       destination="1.1.1"
+       handler="bika.lims.upgrade.v01_01_001.upgrade"
+       profile="bika.lims:default"/>
+
 </configure>

--- a/bika/lims/upgrade/utils.py
+++ b/bika/lims/upgrade/utils.py
@@ -286,6 +286,16 @@ class UpgradeUtils(object):
             self.refreshcatalog.append(cat.id)
         transaction.commit()
 
+    def reindexIndex(self, catalog, index):
+        cat = self._getCatalog(catalog)
+        if index not in cat.indexes():
+            logger.warn("Index {} not found in {}".format(index, catalog))
+            return
+        indexes = self.reindexcatalog.get(cat.id, [])
+        if index not in indexes:
+            indexes.append(index)
+            self.reindexcatalog[cat.id] = indexes
+
     def refreshCatalogs(self):
         """
         It reindexes the modified catalogs but, while cleanAndRebuildCatalogs

--- a/bika/lims/upgrade/v01_01_001.py
+++ b/bika/lims/upgrade/v01_01_001.py
@@ -1,0 +1,37 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from bika.lims import logger
+from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.config import PROJECTNAME as product
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+
+version = '1.1.1'
+profile = 'profile-{0}:default'.format(product)
+
+
+@upgradestep(product, version)
+def upgrade(tool):
+    portal = aq_parent(aq_inner(tool))
+    setup = portal.portal_setup
+    ut = UpgradeUtils(portal)
+    ver_from = ut.getInstalledVersion(product)
+
+    if ut.isOlderVersion(product, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+            product, ver_from, version))
+        # The currently installed version is more recent than the target
+        # version of this upgradestep
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
+
+    # Reindex getPrioritySortkey index. The priority sort key from analyses
+    # takes also into account analyses have to be sorted by their sortkey, so
+    # two analyses with same priority, same AR, but different sort key values
+    # don't get mixed.
+    ut.reindexIndex(CATALOG_ANALYSIS_LISTING, 'getPrioritySortkey')
+    ut.refreshCatalogs()
+
+    logger.info("{0} upgraded to version {1}".format(product, version))
+    return True


### PR DESCRIPTION
Fixes https://github.com/senaite/bika.lims/issues/303

**IMPORTANT**: Requires the execution of upgrade step v1.1.1

In Analyses Add View (when creating a Worksheet), the analyses were displayed randomly. After their selection (and addition into a new Worksheet), the position of the Analysis Requests in the Worksheet was the same as the Analyses Add view, random.

With this Pull Request, the Analyses in Add Analyses view are sorted by priority by default (from more priority to less priority), at the same time that preserves the correct order of analyses in accordance with the SortKey value as defined in the Analysis Service (https://github.com/senaite/bika.lims/pull/331):

![add_analyses_1](https://user-images.githubusercontent.com/832627/32190679-d8944aca-bdae-11e7-8971-87a811413f36.png)

When selected and submitted, the order of the Analysis Requests inside the Worksheet is corrected, so the ARs are sorted in natural order of creation, but again, keeping the Analyses' SortKey order:

![ws](https://user-images.githubusercontent.com/832627/32190804-4c8011bc-bdaf-11e7-9506-ae8b70fa1875.png)

Note the priority of AP-0010-R01 was "High" and the priority of "AP-0005-R01" was medium, so:
a) In Add Analyses view, AP-0010-R01 is displayed before AP-0005-R01
b) In Worksheet manage results, AP-0010-R01 is displayed after AP-0005-R01
c) In both cases, analyses are sorted in accordance with their SortKey value (Iron = 20, Calcium = 50, Magnesium = 70, Copper and others = Not defined)