### PR TITLE
Fix TypeError: "Can't pickle objects in acquisition wrappers" (Calculation)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,8 @@ Changelog
 
 **Fixed**
 
-- #330 Show action buttons when shorting by column in listings
+- #340 Fix TypeError: "Can't pickle objects in acquisition wrappers" (Calculation)
+- #330 Show action buttons when sorting by column in listings
 - #280 Integration of PR-2271. Setting 2 or more CCContacts in AR view produces a Traceback on Save
 - #281 Integration of PR-2269. Show the Unit in Manage Analyses View
 - #282 Integration of PR-2252. Traceback if the title contains braces on content creation

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -459,7 +459,7 @@ class AnalysesView(BikaListingView):
         item['class']['retested'] = 'center'
         item['result_captured'] = self.ulocalized_time(
             obj.getResultCaptureDate, long_format=0)
-        item['calculation'] = obj.getCalculation and True or False
+        item['calculation'] = obj.getCalculationUID
         if obj.meta_type == "ReferenceAnalysis":
             item['DueDate'] = self.ulocalized_time(
                 obj.getExpiryDate, long_format=0)

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -459,7 +459,7 @@ class AnalysesView(BikaListingView):
         item['class']['retested'] = 'center'
         item['result_captured'] = self.ulocalized_time(
             obj.getResultCaptureDate, long_format=0)
-        item['calculation'] = obj.getCalculationUID
+        item['calculation'] = obj.getCalculationUID and True or False
         if obj.meta_type == "ReferenceAnalysis":
             item['DueDate'] = self.ulocalized_time(
                 obj.getExpiryDate, long_format=0)

--- a/bika/lims/catalog/analysis_catalog.py
+++ b/bika/lims/catalog/analysis_catalog.py
@@ -69,7 +69,7 @@ _columns_list = [
     'getClientURL',
     'getAnalysisRequestTitle',
     'getResult',
-    'getCalculation',
+    'getCalculationUID',
     'getUnit',
     'getKeyword',
     'getCategoryTitle',

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1.1.0</version>
+  <version>1.1.2</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -31,4 +31,10 @@
        handler="bika.lims.upgrade.v01_01_001.upgrade"
        profile="bika.lims:default"/>
 
+ <genericsetup:upgradeStep
+       title="Upgrade to Bika LIMS Evo 1.1.2"
+       source="1.1.1"
+       destination="1.1.2"
+       handler="bika.lims.upgrade.v01_01_002.upgrade"
+       profile="bika.lims:default"/>
 </configure>

--- a/bika/lims/upgrade/v01_01_002.py
+++ b/bika/lims/upgrade/v01_01_002.py
@@ -1,0 +1,40 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from bika.lims import logger
+from bika.lims.catalog import CATALOG_ANALYSIS_LISTING
+from bika.lims.config import PROJECTNAME as product
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+
+version = '1.1.2'
+profile = 'profile-{0}:default'.format(product)
+
+
+@upgradestep(product, version)
+def upgrade(tool):
+    portal = aq_parent(aq_inner(tool))
+    setup = portal.portal_setup
+    ut = UpgradeUtils(portal)
+    ver_from = ut.getInstalledVersion(product)
+
+    if ut.isOlderVersion(product, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+            product, ver_from, version))
+        # The currently installed version is more recent than the target
+        # version of this upgradestep
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
+
+    # The assignment of the whole Calculation object in a metadata column
+    # was causing a "TypeError: Can't pickle objects in acquisition wrappers".
+    # getCalculation was only used in analyses listing and can be safely
+    # replaced by getCalculationUID, cause is only used to determine if a
+    # calculation is required to compute the result value
+    # https://github.com/senaite/bika.lims/issues/322
+    ut.delColumn(CATALOG_ANALYSIS_LISTING, 'getCalculation')
+    ut.addColumn(CATALOG_ANALYSIS_LISTING, 'getCalculationUID')
+    ut.refreshCatalogs()
+
+    logger.info("{0} upgraded to version {1}".format(product, version))
+    return True


### PR DESCRIPTION
Fixes https://github.com/senaite/bika.lims/issues/322

The assignment of the whole Calculation object in a metadata column `getCalculation` was causing a "TypeError: Can't pickle objects in acquisition wrappers". 

With this Pull Request, `getCalculation` metadata column has been replaced by `getCalculationUID` in `bika_analysis_catalog`. This metadata field is only used in analyses listing to flag an analysis as it result needs to be calculated.

I've done some functional testing and calculations in manage results view work as expected, also if old calculations are edited (generating new versions). Afak, tests for calculations were the only thing that was failing in https://github.com/senaite/bika.lims/pull/320 . 

**Requires upgrade step v1.1.2**