### PR TITLE
Fix publication preferences for CC Contacts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Changelog
 
 **Fixed**
 
+- #343 Fix publication preferences for CC Contacts
 - #340 Fix TypeError: "Can't pickle objects in acquisition wrappers" (Calculation)
 - #330 Show action buttons when sorting by column in listings
 - #280 Integration of PR-2271. Setting 2 or more CCContacts in AR view produces a Traceback on Save

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -500,7 +500,7 @@ class AnalysisRequestPublishView(BrowserView):
         for cc in ar.getCCContact():
             recips.append({'title': to_utf8(cc.Title()),
                            'email': cc.getEmailAddress(),
-                           'pubpref': contact.getPublicationPreference()})
+                           'pubpref': cc.getPublicationPreference()})
 
         return recips
 


### PR DESCRIPTION
This fixes an issue where no emails were sent to CC Contacts if the primary contact has no publication preferences set.

See https://github.com/bikalims/bika.lims/pull/2281