### PR TITLE
Fix #323: add Attachment to portal_catalog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,8 @@ Changelog
 - #334 Fix TypeError (setRequestID, unexpected keyword argument) on AR Creation
 - #327 Keep Laboratory name when reinstalling
 - #339 Index not found warnings in bika listing.
--      Add Attachment objects to portal_catalog, to allow idserver to function correctly.
+- #348  Add Attachment objects to portal_catalog, to allow idserver to function correctly.
+
 1.0.0 (2017-10-13)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,7 @@ Changelog
 - #334 Fix TypeError (setRequestID, unexpected keyword argument) on AR Creation
 - #327 Keep Laboratory name when reinstalling
 - #339 Index not found warnings in bika listing.
-
+-      Add Attachment objects to portal_catalog, to allow idserver to function correctly.
 1.0.0 (2017-10-13)
 ------------------
 

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -399,7 +399,7 @@ class BikaGenerator(object):
         at.setCatalogsByType('Method', ['bika_setup_catalog', 'portal_catalog'])
         at.setCatalogsByType('Multifile', ['bika_setup_catalog'])
         at.setCatalogsByType('AttachmentType', ['bika_setup_catalog', ])
-        at.setCatalogsByType('Attachment', [])
+        at.setCatalogsByType('Attachment', ['portal_catalog'])
         at.setCatalogsByType('Calculation',
                              ['bika_setup_catalog', 'portal_catalog'])
         at.setCatalogsByType('AnalysisProfile',

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -37,4 +37,12 @@
        destination="1.1.2"
        handler="bika.lims.upgrade.v01_01_002.upgrade"
        profile="bika.lims:default"/>
+
+ <genericsetup:upgradeStep
+       title="Upgrade to Bika LIMS Evo 1.1.3"
+       source="1.1.2"
+       destination="1.1.3"
+       handler="bika.lims.upgrade.v01_01_003.upgrade"
+       profile="bika.lims:default"/>
+
 </configure>

--- a/bika/lims/upgrade/v01_01_003.py
+++ b/bika/lims/upgrade/v01_01_003.py
@@ -1,0 +1,35 @@
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+from Products.CMFCore.utils import getToolByName
+from bika.lims import logger
+from bika.lims.config import PROJECTNAME as product
+from bika.lims.upgrade import upgradestep
+from bika.lims.upgrade.utils import UpgradeUtils
+
+version = '1.1.3'
+profile = 'profile-{0}:default'.format(product)
+
+
+@upgradestep(product, version)
+def upgrade(tool):
+    portal = aq_parent(aq_inner(tool))
+    setup = portal.portal_setup
+    ut = UpgradeUtils(portal)
+    ver_from = ut.getInstalledVersion(product)
+
+    if ut.isOlderVersion(product, version):
+        logger.info("Skipping upgrade of {0}: {1} > {2}".format(
+            product, ver_from, version))
+        # The currently installed version is more recent than the target
+        # version of this upgradestep
+        return True
+
+    logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
+
+    # Attachments must be present in a catalog, otherwise the idserver
+    # will fall apart.  https://github.com/senaite/bika.lims/issues/323
+    at = getToolByName(portal, 'archetype_tool')
+    at.setCatalogsByType('Attachment', ['portal_catalog'])
+
+    logger.info("{0} upgraded to version {1}".format(product, version))
+    return True


### PR DESCRIPTION
This allows idserver to correctly allocate IDs for new attachments.

@Nihadness you were right, there was only one real solution for this.