### PR TITLE
Add "Methods" column and hide unused columns in AS sort list (and fix AS list sorting by default)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Changelog
 
 **Fixed**
 
+- #358 Add "Methods" column and hide unused columns in AS sort list
 - #343 Fix publication preferences for CC Contacts
 - #340 Fix TypeError: "Can't pickle objects in acquisition wrappers" (Calculation)
 - #330 Show action buttons when sorting by column in listings

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -192,11 +192,6 @@ class AnalysisServicesView(BikaListingView):
                 'attr': 'getDepartment.Title',
                 'sortable': not self.do_cats,
             },
-            'Instrument': {
-                'title': _('Instrument'),
-                'toggle': False,
-                'sortable': not self.do_cats,
-            },
             'Unit': {
                 'title': _('Unit'),
                 'attr': 'getUnit',
@@ -251,7 +246,6 @@ class AnalysisServicesView(BikaListingView):
                          'Department',
                          'CommercialID',
                          'ProtocolID',
-                         'Instrument',
                          'Unit',
                          'Price',
                          'MaxTimeAllowed',
@@ -274,7 +268,6 @@ class AnalysisServicesView(BikaListingView):
                          'Department',
                          'CommercialID',
                          'ProtocolID',
-                         'Instrument',
                          'Unit',
                          'Price',
                          'MaxTimeAllowed',
@@ -296,7 +289,6 @@ class AnalysisServicesView(BikaListingView):
                          'Department',
                          'CommercialID',
                          'ProtocolID',
-                         'Instrument',
                          'Unit',
                          'Price',
                          'MaxTimeAllowed',
@@ -353,12 +345,6 @@ class AnalysisServicesView(BikaListingView):
             item['category'] = cat
             if (cat, cat_order) not in self.categories:
                 self.categories.append((cat, cat_order))
-
-        instrument = obj.getInstrument()
-        item['Instrument'] = instrument.Title() if instrument else ''
-        if instrument:
-            item['replace']['Instrument'] = "<a href='%s'>%s</a>" % (
-                instrument.absolute_url() + "/edit", instrument.Title())
 
         calculation = obj.getCalculation()
         item['Calculation'] = calculation.Title() if calculation else ''

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -185,7 +185,6 @@ class AnalysisServicesView(BikaListingView):
                 'attr': 'getMethod.Title',
                 'replace_url': 'getMethod.absolute_url',
                 'sortable': not self.do_cats,
-                'toggle': True
             },
             'Department': {
                 'title': _('Department'),
@@ -195,6 +194,7 @@ class AnalysisServicesView(BikaListingView):
             },
             'Instrument': {
                 'title': _('Instrument'),
+                'toggle': False,
                 'sortable': not self.do_cats,
             },
             'Unit': {
@@ -236,7 +236,6 @@ class AnalysisServicesView(BikaListingView):
                 'title': _('Sort Key'),
                 'attr': 'getSortKey',
                 'sortable': False,
-                'toggle': True
             },
         }
 

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -2,25 +2,25 @@
 #
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+from transaction import savepoint
 
+from Products.ATContentTypes.content.schemata import finalizeATCTSchema
+from Products.Archetypes import atapi
+from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType, safe_unicode
+from Products.Five.browser import BrowserView
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
 from bika.lims.idserver import renameAfterCreation
 from bika.lims.interfaces import IAnalysisServices
+from bika.lims.utils import t
 from bika.lims.utils import tmpID
 from bika.lims.validators import ServiceKeywordValidator
 from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.folder.folder import ATFolder, ATFolderSchema
 from plone.app.layout.globals.interfaces import IViewView
-from Products.Archetypes import atapi
-from Products.ATContentTypes.content.schemata import finalizeATCTSchema
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from transaction import savepoint
 from zope.interface.declarations import implements
 
 
@@ -180,10 +180,8 @@ class AnalysisServicesView(BikaListingView):
                 'attr': 'getCategoryTitle',
                 'sortable': not self.do_cats,
             },
-            'Method': {
-                'title': _('Method'),
-                'attr': 'getMethod.Title',
-                'replace_url': 'getMethod.absolute_url',
+            'Methods': {
+                'title': _('Methods'),
                 'sortable': not self.do_cats,
             },
             'Department': {
@@ -242,7 +240,7 @@ class AnalysisServicesView(BikaListingView):
              'columns': ['Title',
                          'Category',
                          'Keyword',
-                         'Method',
+                         'Methods',
                          'Department',
                          'CommercialID',
                          'ProtocolID',
@@ -264,7 +262,7 @@ class AnalysisServicesView(BikaListingView):
              'columns': ['Title',
                          'Category',
                          'Keyword',
-                         'Method',
+                         'Methods',
                          'Department',
                          'CommercialID',
                          'ProtocolID',
@@ -285,7 +283,7 @@ class AnalysisServicesView(BikaListingView):
              'columns': ['Title',
                          'Keyword',
                          'Category',
-                         'Method',
+                         'Methods',
                          'Department',
                          'CommercialID',
                          'ProtocolID',
@@ -328,16 +326,6 @@ class AnalysisServicesView(BikaListingView):
         return result
 
     def folderitem(self, obj, item, index):
-        if 'obj' in item:
-            obj = item['obj']
-            # Although these should be automatically inserted when bika_listing
-            # searches the schema for fields that match columns, it is still
-            # not harmful to be explicit:
-            item['Keyword'] = obj.getKeyword()
-            item['CommercialID'] = obj.getCommercialID()
-            item['ProtocolID'] = obj.getProtocolID()
-            item['SortKey'] = obj.getSortKey()
-
         cat = obj.getCategoryTitle()
         cat_order = self.an_cats_order.get(cat)
         if self.do_cats:
@@ -353,6 +341,20 @@ class AnalysisServicesView(BikaListingView):
                 calculation.absolute_url() + "/edit", calculation.Title())
 
         item['Price'] = "%s.%02d" % obj.Price
+
+        # Fill Methods column
+        item['Methods'] = ''
+        # if IAnalysisService.providedBy(obj):
+        methods = obj.getMethods()
+        m_dict = {method.Title(): method.absolute_url() for method in methods}
+        m_titles = sorted(m_dict.keys())
+        m_anchors = []
+        for title in m_titles:
+            url = m_dict[title]
+            anchor = '<a href="{}">{}</a>'.format(url, title)
+            m_anchors.append(anchor)
+        item['Methods'] = ', '.join(m_titles)
+        item['replace']['Methods'] = ', '.join(m_anchors)
 
         maxtime = obj.MaxTimeAllowed
         maxtime_string = ""

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -185,7 +185,7 @@ class AnalysisServicesView(BikaListingView):
                 'attr': 'getMethod.Title',
                 'replace_url': 'getMethod.absolute_url',
                 'sortable': not self.do_cats,
-                'toggle': False
+                'toggle': True
             },
             'Department': {
                 'title': _('Department'),
@@ -223,13 +223,13 @@ class AnalysisServicesView(BikaListingView):
             'CommercialID': {
                 'title': _('Commercial ID'),
                 'attr': 'getCommercialID',
-                'toggle': True,
+                'toggle': False,
                 'sortable': not self.do_cats,
             },
             'ProtocolID': {
                 'title': _('Protocol ID'),
                 'attr': 'getProtocolID',
-                'toggle': True,
+                'toggle': False,
                 'sortable': not self.do_cats,
             },
             'SortKey': {

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -152,7 +152,7 @@ class AnalysisServicesView(BikaListingView):
         self.show_select_column = True
         self.show_select_all_checkbox = False
         self.pagesize = 25
-        self.sort_on = 'sortable_title'
+        self.sort_on = 'Title'
         self.categories = []
         self.do_cats = self.context.bika_setup.getCategoriseAnalysisServices()
         if self.do_cats:

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -343,8 +343,6 @@ class AnalysisServicesView(BikaListingView):
         item['Price'] = "%s.%02d" % obj.Price
 
         # Fill Methods column
-        item['Methods'] = ''
-        # if IAnalysisService.providedBy(obj):
         methods = obj.getMethods()
         m_dict = {method.Title(): method.absolute_url() for method in methods}
         m_titles = sorted(m_dict.keys())

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -236,7 +236,7 @@ class AnalysisServicesView(BikaListingView):
                 'title': _('Sort Key'),
                 'attr': 'getSortKey',
                 'sortable': False,
-                'toggle': False
+                'toggle': True
             },
         }
 


### PR DESCRIPTION
This PR fixes https://github.com/senaite/bika.lims/issues/359 and reenables https://github.com/senaite/bika.lims/pull/307 . 

With this PR, the Analysis Services with a SortKey value defined will appear first and sorted by SortKey ascendant. The rest of items will appear below, sorted by Title ascending. 

This PR also contains additional changes regarding column visualization by default:
 - Columns `Commercial ID`, `Protocol ID` have been set as hidden by default
 - Column `SortKey`has been set as visible by default
 - Column `Instrument` has been removed (to prevent confusions with Methods' instruments)
 - Column `Method` has been replaced by `Methods` (because an AS can have multiple methods assigned)

![aslist_new](https://user-images.githubusercontent.com/832627/32490453-908cebaa-c3b3-11e7-94a8-8601f3c7ae3f.png)
