### PR TITLE
Add CCEmails to recipients for AR publication reports

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,7 @@ Changelog
 
 **Fixed**
 
+- #363 Fix AR's CCEmails are nowhere to send Emails out of the LIMS
 - #343 Fix publication preferences for CC Contacts
 - #340 Fix TypeError: "Can't pickle objects in acquisition wrappers" (Calculation)
 - #330 Show action buttons when sorting by column in listings

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -502,6 +502,21 @@ class AnalysisRequestPublishView(BrowserView):
                            'email': cc.getEmailAddress(),
                            'pubpref': cc.getPublicationPreference()})
 
+        # CC Emails
+        # https://github.com/senaite/bika.lims/issues/361
+        plone_utils = getToolByName(self.context, "plone_utils")
+        ccemails = map(lambda x: x.strip(), ar.getCCEmails().split(","))
+        for ccemail in ccemails:
+            # Better do that with a field validator
+            if not plone_utils.validateSingleEmailAddress(ccemail):
+                logger.warn(
+                    "Skipping invalid email address '{}'".format(ccemail))
+                continue
+            recips.append({
+                'title': ccemail,
+                'email': ccemail,
+                'pubpref': ('email', 'pdf',), })
+
         return recips
 
     def get_mail_subject(self, ar):


### PR DESCRIPTION
Fixes https://github.com/senaite/bika.lims/issues/361
Merged from https://github.com/bikalims/bika.lims/pull/2293

**Problem**
CCEmails don't get publication reports via email
Desired behavior after PR is merged

**Resolution**
CCEmails receive publication reports as HTML and attached PDF