### PR TITLE
Error on Manage Results view while Adding new Analyses from different Category  

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,7 @@ Changelog
 - #345 'SearchableText' field and adapter in Batches.
 - #348 Add Attachment objects to portal_catalog, to allow idserver to function correctly.
 - #352 Fix traceback on listings
+- #364 Error on Manage Results view while Adding new Analyses from different Category
 
 
 1.0.0 (2017-10-13)

--- a/bika/lims/browser/js/bika.lims.bikalisting.js
+++ b/bika/lims/browser/js/bika.lims.bikalisting.js
@@ -238,6 +238,9 @@
       $(checked).each(function(e) {
         var transitions;
         transitions = $.parseJSON($(this).attr('data-valid_transitions'));
+        if (!transitions.length) {
+          return;
+        }
         if (restricted_transitions.length > 0) {
           transitions = transitions.filter(function(el) {
             return restricted_transitions.indexOf(el.id) > -1;

--- a/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.bikalisting.coffee
@@ -239,6 +239,8 @@ window.BikaListingTableView = ->
 
         $(checked).each (e) ->
             transitions = $.parseJSON($(this).attr('data-valid_transitions'))
+            if ! transitions.length
+                return
             # Do not want transitions other than those defined in bikalisting
             if restricted_transitions.length > 0
                 transitions = transitions.filter (el) ->


### PR DESCRIPTION
**Current Behavior**
On Manage Results tab of AR's, while adding more Analysis Service, 'Save' button doesn't appear for the first time due to JS error.

**Expected Behavior after this PR**
Save button appears since the first time.

For more detailed information, see https://github.com/senaite/bika.lims/issues/354#event-1329208698