### PR TITLE
Lims Installation fails during setting client permissions in bika setup. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,7 @@ Changelog
 - #345 'SearchableText' field and adapter in Batches.
 - #348 Add Attachment objects to portal_catalog, to allow idserver to function correctly.
 - #352 Fix traceback on listings
+- #365 Lims Installation fails during setting client permissions in bika setup.
 
 
 1.0.0 (2017-10-13)

--- a/bika/lims/subscribers/bikasetup.py
+++ b/bika/lims/subscribers/bikasetup.py
@@ -59,7 +59,7 @@ def set_client_permissions(instance, roles):
         portal_type='Client',
         sort_limit=1)
 
-    if client_permissions_changed(client_chk[0], roles):
+    if client_chk and client_permissions_changed(client_chk[0], roles):
         clients = catalog(portal_type='Client')
         total = len(clients)
         counter = 0


### PR DESCRIPTION
**Current Behavior**
When installing Lims, since there are no clients in the DB, setting client permissions fails.

**Expected Bhevaior after this PR**
No failure due to client permissions when installing Lims. 