### PR TITLE
Corrected the version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup, find_packages
 
-version = '1.0.0'
+version = '1.1.3'
 
 setup(name='bika.lims',
       version=version,


### PR DESCRIPTION
**Current Behaviour**
Lims Version is '1.0.0' in `setup.py`, while it is '1.1.3' in `metadata.xml`.

**Expected Behavior after this PR**
Both versions overlap.