### PR TITLE
Intendation in bika_listing_table_items.pt

### DIFF
--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -227,14 +227,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
             # js checks in row_data if an analysis may be removed.
             row_data = {}
-            # keyword = obj.getKeyword()
-            # if keyword in review_states.keys() \
-            #    and review_states[keyword] not in ['sample_due',
-            #                                       'to_be_sampled',
-            #                                       'to_be_preserved',
-            #                                       'sample_received',
-            #                                       ]:
-            #     row_data['disabled'] = True
             item['row_data'] = json.dumps(row_data)
 
             calculation = obj.getCalculation()

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -227,6 +227,14 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
             # js checks in row_data if an analysis may be removed.
             row_data = {}
+            # keyword = obj.getKeyword()
+            # if keyword in review_states.keys() \
+            #    and review_states[keyword] not in ['sample_due',
+            #                                       'to_be_sampled',
+            #                                       'to_be_preserved',
+            #                                       'sample_received',
+            #                                       ]:
+            #     row_data['disabled'] = True
             item['row_data'] = json.dumps(row_data)
 
             calculation = obj.getCalculation()

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -7,11 +7,6 @@ import json
 
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.layout.globals.interfaces import IViewView
-from zope.i18n.locales import locales
-from zope.interface import implements
-
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
@@ -19,7 +14,10 @@ from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.browser.sample import SamplePartitionsView
 from bika.lims.utils import dicts_to_dict, t
 from bika.lims.utils import logged_in_client
-from bika.lims.workflow import wasTransitionPerformed
+from plone.app.content.browser.interfaces import IFolderContentsView
+from plone.app.layout.globals.interfaces import IViewView
+from zope.i18n.locales import locales
+from zope.interface import implements
 
 
 class AnalysisRequestAnalysesView(BikaListingView):
@@ -226,7 +224,19 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
             item['selected'] = item['uid'] in self.selected
             item['class']['Title'] = 'service_title'
-            row_data = dict()
+
+            # js checks in row_data if an analysis may be removed.
+            row_data = {}
+            # keyword = obj.getKeyword()
+            # if keyword in review_states.keys() \
+            #    and review_states[keyword] not in ['sample_due',
+            #                                       'to_be_sampled',
+            #                                       'to_be_preserved',
+            #                                       'sample_received',
+            #                                       ]:
+            #     row_data['disabled'] = True
+            item['row_data'] = json.dumps(row_data)
+
             calculation = obj.getCalculation()
             item['Calculation'] = calculation and calculation.Title()
 
@@ -247,10 +257,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
             if obj.UID() in self.analyses:
                 analysis = self.analyses[obj.UID()]
-
-                row_data['disabled'] = wasTransitionPerformed(
-                    analysis, 'submit')
-
                 part = analysis.getSamplePartition()
                 part = part and part or obj
                 item['Partition'] = part.Title()
@@ -266,8 +272,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 item["max"] = ''
                 item["error"] = ''
 
-            # js checks in row_data if an analysis may not be editable.
-            item['row_data'] = json.dumps(row_data)
             after_icons = ''
             if obj.getAccredited():
                 after_icons += "<img\

--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -6,370 +6,370 @@
                 global colspan python:1;
                 global colspan_max python:1;"/>
 
-            <tal:items tal:condition="view/this_cat_selected"
+<tal:items tal:condition="view/this_cat_selected"
            tal:repeat="item view/this_cat_batch">
     <tr tal:define="keyword python:item.has_key('Keyword') and item['Keyword'] or '';
                     portal context/@@plone_portal_state/portal;
                     suid python:item.get('service_uid','');
                     tmpstyle python:view.context.bika_setup.getEnableAnalysisRemarks() and 'border-bottom:0 !important;;' or '';
                     tabindex view/tabindex;"
-            tal:attributes="style tmpstyle;
-                        cat python:item.get('category', 'None');
-                        class python:item.get('table_row_class', '');
-                        id string:folder-contents-item-${item/uid};
-                        uid python: item['uid'] if 'uid' in item else None;
-                        keyword python: keyword if keyword else None;
-                        as_uid python: suid if suid else None;
-                        title python: item['title'] if 'title' in item else None;
-                        price python: item['price'] if 'price' in item else None;
-                        vat_percentage python: item['vat_percentage'] if 'vat_percentage' in item else None">
+        tal:attributes="style tmpstyle;
+                    cat python:item.get('category', 'None');
+                    class python:item.get('table_row_class', '');
+                    id string:folder-contents-item-${item/uid};
+                    uid python: item['uid'] if 'uid' in item else None;
+                    keyword python: keyword if keyword else None;
+                    as_uid python: suid if suid else None;
+                    title python: item['title'] if 'title' in item else None;
+                    price python: item['price'] if 'price' in item else None;
+                    vat_percentage python: item['vat_percentage'] if 'vat_percentage' in item else None">
 
-    <tal:comment replace="nothing">*************** Individual items' row_data is stored on each row. ********************************</tal:comment>
+        <tal:comment replace="nothing">*************** Individual items' row_data is stored on each row. ********************************
+        </tal:comment>
 
-    <input type="hidden" tal:attributes="
-        id string:${item/uid}_row_data;
-        value item/row_data|nothing;"/>
+        <input type="hidden" tal:attributes="
+            id string:${item/uid}_row_data;
+            value item/row_data|nothing;"/>
 
-    <tal:comment replace="nothing">*************** Draggable column for manually ordering items ********************************</tal:comment>
+        <tal:comment replace="nothing">*************** Draggable column for manually ordering items ********************************</tal:comment>
 
-    <td tal:condition="view/bika_listing/show_sort_column" class="draggable">
-        <tal:block tal:define="quoted_id item/uid;">
-            <a href=""
+        <td tal:condition="view/bika_listing/show_sort_column" class="draggable">
+            <tal:block tal:define="quoted_id item/uid;">
+                <a href=""
+                        i18n:domain="plone"
+                    title="Move item up"
+                    i18n:attributes="title title_move_item_up;"
+                    tal:attributes="href string:${view/base_url}/folder_position?position=up&amp;id=${quoted_id}">
+                    &#9650;
+                </a>
+                <a href=""
                     i18n:domain="plone"
-                title="Move item up"
-                i18n:attributes="title title_move_item_up;"
-                tal:attributes="href string:${view/base_url}/folder_position?position=up&amp;id=${quoted_id}">
-                &#9650;
-            </a>
-            <a href=""
-                i18n:domain="plone"
-                title="Move item down"
-                i18n:attributes="title title_move_item_down;"
-                tal:attributes="href string:${view/base_url}/folder_position?position=down&amp;id=${quoted_id}">
-                &#9660;
-            </a>
-        </tal:block>
-    </td>
+                    title="Move item down"
+                    i18n:attributes="title title_move_item_down;"
+                    tal:attributes="href string:${view/base_url}/folder_position?position=down&amp;id=${quoted_id}">
+                    &#9660;
+                </a>
+            </tal:block>
+        </td>
 
-<tal:comment replace="nothing">***************
-Item select checkboxes.
-********************************</tal:comment>
-<td style="width:20px;"
-    tal:condition="view/bika_listing/show_select_column"
-    tal:define="cl python:'class' in item and 'select_column' in item['class'] and
-                item['class']['select_column'] or '';"
-    tal:attributes="class string:notDraggable ${item/state_class} $cl">
-<tal:replace
-    tal:condition="python: 'replace' in item and 'select_column' in item['replace']"
-    tal:content="structure python: item['replace']['select_column']"/>
-<tal:noreplace
-    tal:condition="python: 'replace' not in item or 'select_column' not in item['replace']">
-    <input type="checkbox"
-        class="noborder"
-        tal:attributes="
-            name    string:${view/bika_listing/select_checkbox_name}:list;
-            value   item/uid;
-            id  string:${view/bika_listing/form_id}_cb_${item/uid};
-            item_title item/title;
-            alt item/title;
-            tabindex string:1000;
-            selector python:str(item['obj'].aq_parent.getId() if hasattr(item.get('obj', ''), 'aq_parent') else '') + '_' + item['id'];
-            checked python:item.has_key('selected') and item['selected'] and 'yes' or '';
-            data-valid_transitions python:'{}'"/>
-    <input type="hidden"
-        name="selected_obj_uids:list"
-        value="#"
-        tal:attributes="
-            value item/uid;
-            name string:${view/bika_listing/form_id}_selected_obj_uids:list" />
-    <label
-        tal:content="item/title"
-        tal:attributes="for string:${view/bika_listing/form_id}_cb_${item/uid}"
-        class="hiddenStructure"/>
-</tal:noreplace>
-</td>
+        <tal:comment replace="nothing">
+            ***************Item select checkboxes.********************************
+        </tal:comment>
+        <td style="width:20px;"
+            tal:condition="view/bika_listing/show_select_column"
+            tal:define="cl python:'class' in item and 'select_column' in item['class'] and
+                        item['class']['select_column'] or '';"
+            tal:attributes="class string:notDraggable ${item/state_class} $cl">
+            <tal:replace
+                tal:condition="python: 'replace' in item and 'select_column' in item['replace']"
+                tal:content="structure python: item['replace']['select_column']"/>
+            <tal:noreplace
+                tal:condition="python: 'replace' not in item or 'select_column' not in item['replace']">
 
-<tal:comment replace="nothing">***************  TD.
-Table cells for each column from in review_state's column list.
-********************</tal:comment>
-
-<tal:cell
-    tal:repeat="column view/bika_listing/review_state/columns">
-<tal:rowcolspan
-    tal:condition="python: 'toggle' not in view.bika_listing.columns[column]
-                        or view.bika_listing.columns[column].get('toggle', True)"
-    tal:define="
-        dummy python: 'rowspan' in item and column in item['rowspan'] and rowspan_max.update({column: item['rowspan'][column]});
-        dummy python: column in rowspan_max or rowspan_max.update({column: 1});
-        dummy python: rowspan.update({column: 'rowspan' in item and column in item['rowspan'] and item['rowspan'][column] or rowspan.get('column', 2)-1});
-        global colspan_max python: 'colspan' in item and column in item['colspan'] and int(item['colspan'][column]) or colspan_max;
-        global colspan python:  'colspan' in item and column in item['colspan'] and int(item['colspan'][column]) or (colspan - 1);
-        global colspan_max python: colspan < 1 and 1 or colspan_max;
-        global colspan python:  colspan < 1 and 1 or colspan;">
-<td
-    tal:condition="python:rowspan[column] == rowspan_max[column] and colspan == colspan_max"
-    tal:define="
-        allow_edit python:view.bika_listing.allow_edit
-                        and column in item['allow_edit']
-                        and item.get('edit_condition', {}).get(column, True);
-        required python:'required' in item and column in item['required'] or False;
-        field python: item['field'].get(column, '') if item.get('field', '') else '';
-        before python:column in item['before'] and
-            item['before'][column] or '';
-        after python:column in item['after'] and
-            item['after'][column] or '';
-        replace python:column in item['replace'] and
-            item['replace'][column] or '';
-        field_type python:'type' in view.bika_listing.columns[column] and
-            view.bika_listing.columns[column]['type'] or 'string';
-        field_type python:'choices' in item and column in item['choices'] and
-            'choices' or field_type;
-        input_class python:'input_class' in view.bika_listing.columns[column] and
-            view.bika_listing.columns[column]['input_class'] or 'numeric';
-        input_width python:'input_width' in view.bika_listing.columns[column] and
-            view.bika_listing.columns[column]['input_width'] or '5';
-        table_row_class python:'table_row_class' in view.bika_listing.columns[column] and
-            view.bika_listing.columns[column]['table_row_class'] or '';
-        klass python:column in item['class'] and
-            item['class'][column] or '';"
-    tal:attributes="
-        class python:' '.join((table_row_class, klass, item['state_class'], column));
-        rowspan python:rowspan[column];
-        colspan python:colspan;">
-
-<tal:comment replace="nothing"><!-- before structure --></tal:comment>
-<span class="before"
-    tal:content="structure before"/>
-
-<tal:comment replace="nothing"><!-- replace structure --></tal:comment>
-<tal:before
-    tal:replace="structure replace"/>
-
-<span tal:omit-tag="python:True"
-    tal:condition="not:replace">
-
-<span tal:omit-tag="python:True"
-    tal:condition="python:field_type == 'string'">
-    <tal:comment replace="nothing"><!-- string --></tal:comment>
-    <tal:comment replace="nothing"><!-- interim field --></tal:comment>
-    <span tal:omit-tag="python:True"
-        tal:condition="python:type(item[column]) == type({})">
-        <tal:comment replace="nothing"><!-- edit --></tal:comment>
-        <input
-            type="text" style="font-size: 100%"
-            autocomplete="off"
-            tal:condition="python:allow_edit"
-            tal:attributes="
-                selector string:${column}_${item/id};
-                class python:'listing_string_entry %s' % input_class;
-                tabindex tabindex/next;
-                size input_width;
-                uid string:${item/uid};
-                as_uid string:${item/service_uid|nothing};
-                st_uid string:${item/st_uid|nothing};
-                objectId string:${item/id};
-                field python:field if field else column;
-                value python:item[column]['value'];"/>
-        <tal:comment replace="nothing"><!-- view --></tal:comment>
-        <span
-            tal:condition="python:not allow_edit"
-            tal:content="python:item[column]['formatted_value']"
-            tal:attributes="class item/state_class"/>
-        <input
-            type="hidden"
-            tal:condition="python:not allow_edit"
-            tal:attributes="
-                selector string:${column}_${item/id};
-                size input_width;
-                uid string:${item/uid};
-                as_uid string:${item/service_uid|nothing};
-                st_uid string:${item/st_uid|nothing};
-                field python:field if field else column;
-                value python:item[column]['value'];"/>
-        <tal:comment replace="nothing"><!-- unit for interim field--></tal:comment>
-        <em tal:condition="python:'unit' in item[column]"
-            class="discreet"
-            style="white-space:nowrap;"
-            tal:content="structure python:item[column]['unit']"/>
-    </span>
-    <tal:comment replace="nothing"><!-- regular field --></tal:comment>
-    <span tal:omit-tag="python:True"
-        tal:condition="python:not isinstance(item[column], dict) and
-                        not (column == 'Result' and item.get('calculation', False))">
-        <tal:comment replace="nothing"><!-- edit --></tal:comment>
-        <input
-            type="text" style="font-size: 100%"
-            autocomplete="off"
-            tal:condition="python:allow_edit"
-            tal:attributes="
-                selector string:${column}_${item/id};
-                class python:'listing_string_entry %s' % input_class;
-                tabindex tabindex/next;
-                size input_width;
-                uid string:${item/uid};
-                as_uid string:${item/service_uid|nothing};
-                st_uid string:${item/st_uid|nothing};
-                objectId string:${item/id};
-                field python:field if field else column;
-                name python:column == view.bika_listing.select_checkbox_name and '%s_column_value.%s:records'%(column, item['uid']) or '%s.%s:records'%(column, item['uid']);
-                value python:item[column] if item[column] is not None else '';"/>
-        <tal:comment replace="nothing"><!-- view --></tal:comment>
-        <span
-            tal:condition="python:not allow_edit and column == 'Result' and item.get('formatted_result', '')"
-            tal:content="structure python:item['formatted_result']"
-            tal:attributes="class item/state_class"></span>
-        <span
-            tal:condition="python:not allow_edit and column == 'Result' and not item.get('formatted_result', '')"
-            tal:content="python:item.get('formatted_result', '')"
-            tal:attributes="class item/state_class"></span>
-        <tal:regularlabel condition="python:not allow_edit and column != 'Result'">
-        <span tal:condition="python:item.get('structure',False)"
-            tal:content="structure python:item[column] if item[column] is not None else ''"
-            tal:attributes="class item/state_class"></span>
-        <span tal:condition="python:not item.get('structure',False)"
-            tal:content="python:item[column] if item[column] is not None else ''"
-            tal:attributes="class item/state_class"></span>
-        </tal:regularlabel>
-        <input
-            type="hidden"
-            tal:condition="python:not allow_edit"
-            tal:attributes="
-                selector string:${column}_${item/id};
-                size input_width;
-                uid string:${item/uid};
-                as_uid string:${item/service_uid|nothing};
-                st_uid string:${item/st_uid|nothing};
-                objectId string:${item/id};
-                field python:field if field else column;
-                name python:column == view.bika_listing.select_checkbox_name and '%s_column_value.%s:records'%(column, item['uid']) or '%s.%s:records'%(column, item['uid']);
-                value python:item[column];"/>
-    </span>
-    <tal:comment replace="nothing"><!-- calculated result field. --></tal:comment>
-    <span tal:omit-tag="python:True"
-        tal:condition="python:column == 'Result' and item.get('calculation', False)">
-        <span
-            tal:attributes="
-                field string:formatted_result;
-                uid item/uid;
-                objectId string:${item/id};
-                size input_width;"
-            tal:content="structure python:item.get('formatted_result', '')"/>
-        <input
-            type="hidden"
-            tal:attributes="
-                selector string:${column}_${item/id};
-                uid string:${item/uid};
-                as_uid string:${item/service_uid|nothing};
-                st_uid string:${item/st_uid|nothing};
-                objectId string:${item/id};
-                field string:Result;
-                name string:Result.${item/uid}:records;
-                value python:item['Result'];"/>
-    </span>
-
-</span>
-
-<tal:comment replace="nothing"><!-- boolean --></tal:comment>
-<span tal:omit-tag="python:True"
-    tal:condition="python:field_type == 'boolean'">
-    <input
-        type="checkbox" style="font-size: 100%"
-        tal:condition="allow_edit"
-        tal:attributes="
-            selector string:${column}_${item/id};
-            class python: item.get('state_class', '') + ' '  + input_class;
-            uid string:${item/uid};
-            id python:'%s-%s' % (item['uid'], column);
-            field python:field if field else column;
-            name string:${column}.${item/uid}:record:ignore-empty;
-            checked python:item.get(column) and 'yes' or '';"/>
-    <tal:comment replace="nothing"><!-- will not display if readonly and false --></tal:comment>
-    <input
-        type="checkbox"
-        tal:condition="python:not allow_edit and item.get(column)"
-        disabled="disabled"
-        tal:attributes="
-            selector string:${column}_${item/id};
-            class item/state_class;
-            checked python:item.get(column) and 'yes' or '';"/>
-</span>
-
-<tal:comment replace="nothing"><!-- choices --></tal:comment>
-<span tal:omit-tag="python:True"
-    tal:condition="python:field_type == 'choices'">
-    <span tal:condition="python: allow_edit">
-        <select style="font-size: 100%"
-            tal:condition="python:column in item['choices']"
-            tal:attributes="
-                selector string:${column}_${item/id};
-                tabindex tabindex/next;
-                class python:'listing_select_entry %s' % input_class;
-                field python:field if field else column;
-                name string:${column}.${item/uid}:records;
-                as_uid string:${item/service_uid|nothing};
-                uid item/uid;">
-            <option value="" tal:condition="not:required"></option>
-            <tal:options tal:repeat="option python:item['choices'][column]">
-                <option
+                <input type="checkbox"
+                    class="noborder"
                     tal:attributes="
-                        value python:option['ResultValue'];
-                        selected python:item[column] == option['ResultValue']
-                                        and 'selected' or '';"
-                    tal:content="python:option['ResultText']">
-                </option>
-            </tal:options>
-        </select>
-    </span>
-    <span tal:omit-tag="python:True"
-        tal:condition="python:not allow_edit">
-        <span>
-            <input
-                type="hidden"
-                tal:attributes="
-                    as_uid string:${item/service_uid|nothing};
-                    uid string:${item/uid};
-                    field python:field if field else column;
-                    value python:item[column];
-                    name string:${column}.${item/uid}:records"/>
-        </span>
-        <span tal:condition="python:item.get('formatted_result','')"
-              tal:content="structure python:item['formatted_result']"
-              tal:attributes="class string:${item/state_class} result"/>
-        <span tal:condition="python:not item.get('formatted_result','')"
-              tal:content="python:item[column]"
-              tal:attributes="class string:${item/state_class} result"/>
-    </span>
-</span>
+                        name    string:${view/bika_listing/select_checkbox_name}:list;
+                        value   item/uid;
+                        id  string:${view/bika_listing/form_id}_cb_${item/uid};
+                        item_title item/title;
+                        alt item/title;
+                        tabindex string:1000;
+                        selector python:str(item['obj'].aq_parent.getId() if hasattr(item.get('obj', ''), 'aq_parent') else '') + '_' + item['id'];
+                        checked python:item.has_key('selected') and item['selected'] and 'yes' or '';
+                        data-valid_transitions python:'{}'"/>
+                <input type="hidden"
+                    name="selected_obj_uids:list"
+                    value="#"
+                    tal:attributes="
+                        value item/uid;
+                        name string:${view/bika_listing/form_id}_selected_obj_uids:list" />
+                <label
+                    tal:content="item/title"
+                    tal:attributes="for string:${view/bika_listing/form_id}_cb_${item/uid}"
+                    class="hiddenStructure"/>
+            </tal:noreplace>
+        </td>
 
-<tal:comment replace="nothing"><!-- unit for result--></tal:comment>
-<em tal:condition="python:'Unit' in item and column == 'Result'"
-    class="discreet"
-    style="white-space:nowrap;"
-    tal:content="structure python:item['Unit']"/>
+        <tal:comment replace="nothing">***************  TD.Table cells for
+            each column from in review_state's column list.
+            ********************
+        </tal:comment>
 
-</span>
+        <tal:cell
+            tal:repeat="column view/bika_listing/review_state/columns">
+            <tal:rowcolspan
+                tal:condition="python: 'toggle' not in view.bika_listing.columns[column]
+                                    or view.bika_listing.columns[column].get('toggle', True)"
+                tal:define="
+                    dummy python: 'rowspan' in item and column in item['rowspan'] and rowspan_max.update({column: item['rowspan'][column]});
+                    dummy python: column in rowspan_max or rowspan_max.update({column: 1});
+                    dummy python: rowspan.update({column: 'rowspan' in item and column in item['rowspan'] and item['rowspan'][column] or rowspan.get('column', 2)-1});
+                    global colspan_max python: 'colspan' in item and column in item['colspan'] and int(item['colspan'][column]) or colspan_max;
+                    global colspan python:  'colspan' in item and column in item['colspan'] and int(item['colspan'][column]) or (colspan - 1);
+                    global colspan_max python: colspan < 1 and 1 or colspan_max;
+                    global colspan python:  colspan < 1 and 1 or colspan;">
+                <td
+                    tal:condition="python:rowspan[column] == rowspan_max[column] and colspan == colspan_max"
+                    tal:define="
+                        allow_edit python:view.bika_listing.allow_edit
+                                        and column in item['allow_edit']
+                                        and item.get('edit_condition', {}).get(column, True);
+                        required python:'required' in item and column in item['required'] or False;
+                        field python: item['field'].get(column, '') if item.get('field', '') else '';
+                        before python:column in item['before'] and
+                            item['before'][column] or '';
+                        after python:column in item['after'] and
+                            item['after'][column] or '';
+                        replace python:column in item['replace'] and
+                            item['replace'][column] or '';
+                        field_type python:'type' in view.bika_listing.columns[column] and
+                            view.bika_listing.columns[column]['type'] or 'string';
+                        field_type python:'choices' in item and column in item['choices'] and
+                            'choices' or field_type;
+                        input_class python:'input_class' in view.bika_listing.columns[column] and
+                            view.bika_listing.columns[column]['input_class'] or 'numeric';
+                        input_width python:'input_width' in view.bika_listing.columns[column] and
+                            view.bika_listing.columns[column]['input_width'] or '5';
+                        table_row_class python:'table_row_class' in view.bika_listing.columns[column] and
+                            view.bika_listing.columns[column]['table_row_class'] or '';
+                        klass python:column in item['class'] and
+                            item['class'][column] or '';"
+                    tal:attributes="
+                        class python:' '.join((table_row_class, klass, item['state_class'], column));
+                        rowspan python:rowspan[column];
+                        colspan python:colspan;">
 
-<span class="after" tal:content="structure after"/>
-<tal:has_field_icons condition="python:hasattr(view.bika_listing, 'field_icons')">
-    <tal:field_icons define="uid python:item['uid'];
-                            val python:view.bika_listing.field_icons.get(uid, []);
-                            field_icons python: [i for i in val if i['field'] == column];">
-        <span class="bika-alert"
-                tal:attributes="uid uid;
-                                field column;">
-                <img tal:repeat="field_icon field_icons"
-                    tal:attributes="src python:portal.absolute_url()+'/'+field_icon['icon'];
-                                    title python:field_icon['msg']"/>
-        </span>
-    </tal:field_icons>
-</tal:has_field_icons>
-</td>
-</tal:rowcolspan>
-</tal:cell>
+                    <tal:comment replace="nothing"><!-- before structure --></tal:comment>
+                    <span class="before"
+                        tal:content="structure before"/>
 
-</tr>
+                    <tal:comment replace="nothing"><!-- replace structure --></tal:comment>
+                    <tal:before tal:replace="structure replace"/>
 
-<tal:get_colspan tal:define="
+                    <span tal:omit-tag="python:True"
+                          tal:condition="not:replace">
+
+                        <span tal:omit-tag="python:True"
+                            tal:condition="python:field_type == 'string'">
+                            <tal:comment replace="nothing"><!-- string --></tal:comment>
+                            <tal:comment replace="nothing"><!-- interim field --></tal:comment>
+                            <span tal:omit-tag="python:True"
+                                tal:condition="python:type(item[column]) == type({})">
+                                <tal:comment replace="nothing"><!-- edit --></tal:comment>
+                                <input
+                                    type="text" style="font-size: 100%"
+                                    autocomplete="off"
+                                    tal:condition="python:allow_edit"
+                                    tal:attributes="
+                                        selector string:${column}_${item/id};
+                                        class python:'listing_string_entry %s' % input_class;
+                                        tabindex tabindex/next;
+                                        size input_width;
+                                        uid string:${item/uid};
+                                        as_uid string:${item/service_uid|nothing};
+                                        st_uid string:${item/st_uid|nothing};
+                                        objectId string:${item/id};
+                                        field python:field if field else column;
+                                        value python:item[column]['value'];"/>
+                                <tal:comment replace="nothing"><!-- view --></tal:comment>
+                                <span
+                                    tal:condition="python:not allow_edit"
+                                    tal:content="python:item[column]['formatted_value']"
+                                    tal:attributes="class item/state_class"/>
+                                <input
+                                    type="hidden"
+                                    tal:condition="python:not allow_edit"
+                                    tal:attributes="
+                                        selector string:${column}_${item/id};
+                                        size input_width;
+                                        uid string:${item/uid};
+                                        as_uid string:${item/service_uid|nothing};
+                                        st_uid string:${item/st_uid|nothing};
+                                        field python:field if field else column;
+                                        value python:item[column]['value'];"/>
+                                <tal:comment replace="nothing"><!-- unit for interim field--></tal:comment>
+                                <em tal:condition="python:'unit' in item[column]"
+                                    class="discreet"
+                                    style="white-space:nowrap;"
+                                    tal:content="structure python:item[column]['unit']"/>
+                            </span>
+                            <tal:comment replace="nothing"><!-- regular field --></tal:comment>
+                            <span tal:omit-tag="python:True"
+                                tal:condition="python:not isinstance(item[column], dict) and
+                                                not (column == 'Result' and item.get('calculation', False))">
+                                <tal:comment replace="nothing"><!-- edit --></tal:comment>
+                                <input
+                                    type="text" style="font-size: 100%"
+                                    autocomplete="off"
+                                    tal:condition="python:allow_edit"
+                                    tal:attributes="
+                                        selector string:${column}_${item/id};
+                                        class python:'listing_string_entry %s' % input_class;
+                                        tabindex tabindex/next;
+                                        size input_width;
+                                        uid string:${item/uid};
+                                        as_uid string:${item/service_uid|nothing};
+                                        st_uid string:${item/st_uid|nothing};
+                                        objectId string:${item/id};
+                                        field python:field if field else column;
+                                        name python:column == view.bika_listing.select_checkbox_name and '%s_column_value.%s:records'%(column, item['uid']) or '%s.%s:records'%(column, item['uid']);
+                                        value python:item[column] if item[column] is not None else '';"/>
+                                <tal:comment replace="nothing"><!-- view --></tal:comment>
+                                <span
+                                    tal:condition="python:not allow_edit and column == 'Result' and item.get('formatted_result', '')"
+                                    tal:content="structure python:item['formatted_result']"
+                                    tal:attributes="class item/state_class"></span>
+                                <span
+                                    tal:condition="python:not allow_edit and column == 'Result' and not item.get('formatted_result', '')"
+                                    tal:content="python:item.get('formatted_result', '')"
+                                    tal:attributes="class item/state_class"></span>
+                                <tal:regularlabel condition="python:not allow_edit and column != 'Result'">
+                                <span tal:condition="python:item.get('structure',False)"
+                                    tal:content="structure python:item[column] if item[column] is not None else ''"
+                                    tal:attributes="class item/state_class"></span>
+                                <span tal:condition="python:not item.get('structure',False)"
+                                    tal:content="python:item[column] if item[column] is not None else ''"
+                                    tal:attributes="class item/state_class"></span>
+                                </tal:regularlabel>
+                                <input
+                                    type="hidden"
+                                    tal:condition="python:not allow_edit"
+                                    tal:attributes="
+                                        selector string:${column}_${item/id};
+                                        size input_width;
+                                        uid string:${item/uid};
+                                        as_uid string:${item/service_uid|nothing};
+                                        st_uid string:${item/st_uid|nothing};
+                                        objectId string:${item/id};
+                                        field python:field if field else column;
+                                        name python:column == view.bika_listing.select_checkbox_name and '%s_column_value.%s:records'%(column, item['uid']) or '%s.%s:records'%(column, item['uid']);
+                                        value python:item[column];"/>
+                            </span>
+                            <tal:comment replace="nothing"><!-- calculated result field. --></tal:comment>
+                            <span tal:omit-tag="python:True"
+                                tal:condition="python:column == 'Result' and item.get('calculation', False)">
+                                <span
+                                    tal:attributes="
+                                        field string:formatted_result;
+                                        uid item/uid;
+                                        objectId string:${item/id};
+                                        size input_width;"
+                                    tal:content="structure python:item.get('formatted_result', '')"/>
+                                <input
+                                    type="hidden"
+                                    tal:attributes="
+                                        selector string:${column}_${item/id};
+                                        uid string:${item/uid};
+                                        as_uid string:${item/service_uid|nothing};
+                                        st_uid string:${item/st_uid|nothing};
+                                        objectId string:${item/id};
+                                        field string:Result;
+                                        name string:Result.${item/uid}:records;
+                                        value python:item['Result'];"/>
+                            </span>
+                        </span>
+
+                        <tal:comment replace="nothing"><!-- boolean --></tal:comment>
+                        <span tal:omit-tag="python:True"
+                            tal:condition="python:field_type == 'boolean'">
+                            <input
+                                type="checkbox" style="font-size: 100%"
+                                tal:condition="allow_edit"
+                                tal:attributes="
+                                    selector string:${column}_${item/id};
+                                    class python: item.get('state_class', '') + ' '  + input_class;
+                                    uid string:${item/uid};
+                                    id python:'%s-%s' % (item['uid'], column);
+                                    field python:field if field else column;
+                                    name string:${column}.${item/uid}:record:ignore-empty;
+                                    checked python:item.get(column) and 'yes' or '';"/>
+                            <tal:comment replace="nothing"><!-- will not display if readonly and false --></tal:comment>
+                            <input
+                                type="checkbox"
+                                tal:condition="python:not allow_edit and item.get(column)"
+                                disabled="disabled"
+                                tal:attributes="
+                                    selector string:${column}_${item/id};
+                                    class item/state_class;
+                                    checked python:item.get(column) and 'yes' or '';"/>
+                        </span>
+                        <tal:comment replace="nothing"><!-- choices --></tal:comment>
+                        <span tal:omit-tag="python:True"
+                            tal:condition="python:field_type == 'choices'">
+                            <span tal:condition="python: allow_edit">
+                                <select style="font-size: 100%"
+                                    tal:condition="python:column in item['choices']"
+                                    tal:attributes="
+                                        selector string:${column}_${item/id};
+                                        tabindex tabindex/next;
+                                        class python:'listing_select_entry %s' % input_class;
+                                        field python:field if field else column;
+                                        name string:${column}.${item/uid}:records;
+                                        as_uid string:${item/service_uid|nothing};
+                                        uid item/uid;">
+                                    <option value="" tal:condition="not:required"></option>
+                                    <tal:options tal:repeat="option python:item['choices'][column]">
+                                        <option
+                                            tal:attributes="
+                                                value python:option['ResultValue'];
+                                                selected python:item[column] == option['ResultValue']
+                                                                and 'selected' or '';"
+                                            tal:content="python:option['ResultText']">
+                                        </option>
+                                    </tal:options>
+                                </select>
+                            </span>
+                            <span tal:omit-tag="python:True"
+                                tal:condition="python:not allow_edit">
+                                <span>
+                                    <input
+                                        type="hidden"
+                                        tal:attributes="
+                                            as_uid string:${item/service_uid|nothing};
+                                            uid string:${item/uid};
+                                            field python:field if field else column;
+                                            value python:item[column];
+                                            name string:${column}.${item/uid}:records"/>
+                                </span>
+                                <span tal:condition="python:item.get('formatted_result','')"
+                                      tal:content="structure python:item['formatted_result']"
+                                      tal:attributes="class string:${item/state_class} result"/>
+                                <span tal:condition="python:not item.get('formatted_result','')"
+                                      tal:content="python:item[column]"
+                                      tal:attributes="class string:${item/state_class} result"/>
+                            </span>
+                        </span>
+
+                        <tal:comment replace="nothing"><!-- unit for result--></tal:comment>
+                        <em tal:condition="python:'Unit' in item and column == 'Result'"
+                        class="discreet"
+                        style="white-space:nowrap;"
+                        tal:content="structure python:item['Unit']"/>
+
+                    </span>
+
+                    <span class="after" tal:content="structure after"/>
+                    <tal:has_field_icons condition="python:hasattr(view.bika_listing, 'field_icons')">
+                        <tal:field_icons define="uid python:item['uid'];
+                                        val python:view.bika_listing.field_icons.get(uid, []);
+                                        field_icons python: [i for i in val if i['field'] == column];">
+                            <span class="bika-alert"
+                                tal:attributes="uid uid;
+                                            field column;">
+                                <img tal:repeat="field_icon field_icons"
+                                    tal:attributes="src python:portal.absolute_url()+'/'+field_icon['icon'];
+                                                title python:field_icon['msg']"/>
+                            </span>
+                        </tal:field_icons>
+                    </tal:has_field_icons>
+                </td>
+            </tal:rowcolspan>
+        </tal:cell>
+
+    </tr>
+
+    <tal:get_colspan tal:define="
         form_id view/bika_listing/form_id;
         review_state_id python:request.get(form_id+'_review_state', 'default');
         review_state python:[t for t in view.bika_listing.review_states if t['id'] == review_state_id];
@@ -379,47 +379,47 @@ Table cells for each column from in review_state's column list.
         nr_cols python:view.bika_listing.show_sort_column and nr_cols + 1 or nr_cols;
         nr_cols python:str(nr_cols);">
 
-    <!-- Row Range comments field (for Analysis Specifications) -->
-    <tal:rangecomments
-        condition="python:view.context.portal_type=='AnalysisSpec'"
-        define="column string:rangecomment;
-                allow_edit python:view.bika_listing.allow_edit \
+        <!-- Row Range comments field (for Analysis Specifications) -->
+        <tal:rangecomments
+            condition="python:view.context.portal_type=='AnalysisSpec'"
+            define="column string:rangecomment;
+                    allow_edit python:view.bika_listing.allow_edit \
                                 and item.get('edit_condition', {}).get(column, True)">
-        <tr tal:attributes="class item/table_row_class;
+            <tr tal:attributes="class item/table_row_class;
                             cat python:item.get('category', 'None');
                             id string:folder-contents-item-${item/uid};
                             uid item/uid;">
-           <td tal:attributes="class string:${item/state_class} result"></td>
-           <td tal:attributes="colspan python:int(nr_cols)-1;
-                                class string:${item/state_class} result"
-                style="padding-right:10px;padding-bottom:5px;">
-                <span i18n:translate="">Range remarks:</span>&nbsp;
-                <textarea
-                    style="width:100%;display:block;"
-                    autocomplete="off"
-                    tal:condition="allow_edit"
-                    tal:attributes="
-                        selector string:${column}_${item/id};
-                        class python:'listing_remarks';
-                        uid string:${item/uid};
-                        as_uid string:${item/service_uid|nothing};
-                        st_uid string:${item/st_uid|nothing};
-                        objectId string:${item/id};
-                        field python:column;
-                        value python:item[column];
-                        originalvalue python:item[column];
-                        name string:${column}.${item/uid}:records"
+                <td tal:attributes="class string:${item/state_class} result"></td>
+                <td tal:attributes="colspan python:int(nr_cols)-1;
+                        class string:${item/state_class} result"
+                        style="padding-right:10px;padding-bottom:5px;">
+                    <span i18n:translate="">Range remarks:</span>&nbsp;
+                    <textarea
+                        style="width:100%;display:block;"
+                        autocomplete="off"
+                        tal:condition="allow_edit"
+                        tal:attributes="
+                            selector string:${column}_${item/id};
+                            class python:'listing_remarks';
+                            uid string:${item/uid};
+                            as_uid string:${item/service_uid|nothing};
+                            st_uid string:${item/st_uid|nothing};
+                            objectId string:${item/id};
+                            field python:column;
+                            value python:item[column];
+                            originalvalue python:item[column];
+                            name string:${column}.${item/uid}:records"
                     tal:content="python:item[column]"></textarea>
-                <span
-                    autocomplete="off"
-                    tal:condition="python:not allow_edit"
-                    tal:content="python:item[column]['value']"/>
-            </td>
-        </tr>
-    </tal:rangecomments>
+                    <span
+                        autocomplete="off"
+                        tal:condition="python:not allow_edit"
+                        tal:content="python:item[column]['value']"/>
+                </td>
+            </tr>
+        </tal:rangecomments>
 
-    <!-- Row Remarks field (for Analyses) -->
-    <tal:remarks_condition
+        <!-- Row Remarks field (for Analyses) -->
+        <tal:remarks_condition
         tal:define="remarksenabled python:view.context.bika_setup.getEnableAnalysisRemarks();
                     isanalysis python:'obj' in item and item['obj'].meta_type in ['Analysis', 'DuplicateAnalysis', 'ReferenceAnalysis'];
                     hasremarks python:True if item.get('Remarks','') else False;
@@ -427,44 +427,44 @@ Table cells for each column from in review_state's column list.
                     isforaggregatedlist python: True if review_state_id=='to_be_verified' else False;
                     showremarks python:isanalysis and (hasremarks or remarksedit or isforaggregatedlist)">
 
-        <tr tal:condition="showremarks"
-            tal:define="keyword python:item.has_key('Keyword') and item['Keyword'] or '';"
-            tal:attributes="class item/table_row_class;
+            <tr tal:condition="showremarks"
+                tal:define="keyword python:item.has_key('Keyword') and item['Keyword'] or '';"
+                tal:attributes="class item/table_row_class;
                         id string:folder-contents-item-${item/uid};
                         uid item/uid;
                         keyword keyword;">
 
-            <td tal:attributes="class string:${item/state_class} result"></td>
+                <td tal:attributes="class string:${item/state_class} result"></td>
 
-            <td tal:attributes="colspan python:int(nr_cols)-1;
-                                class string:${item/state_class} result remarks"
-                style="padding-right:10px;padding-bottom:5px;">
-                <span i18n:translate="">Remarks:</span>&nbsp;
-                <textarea
-                    style="width:100%;display:block;"
-                    autocomplete="off"
-                    rows="1"
-                    tal:content="python:item.get('Remarks','')"
-                    tal:condition="python:remarksedit==True"
-                    tal:attributes="
-                        class python:'listing_remarks';
-                        uid string:${item/uid};
-                        as_uid string:${item/service_uid|nothing};
-                        st_uid string:${item/st_uid|nothing};
-                        objectId string:${item/id};
-                        name string:Remarks.${item/uid}:records;
-                        value python:item.get('Remarks', '');"></textarea>
-                <span
-                    autocomplete="off"
-                    tal:condition="python:remarksedit==False"
-                    tal:attributes="
-                        class python:'listing_remarks';
-                        name string:Remarks.${item/uid}:records;"
-                    tal:content="python:item.get('Remarks', '') if hasremarks else 'No Remarks.'"/>
-            </td>
-        </tr>
-    </tal:remarks_condition>
+                <td tal:attributes="colspan python:int(nr_cols)-1;
+                                    class string:${item/state_class} result remarks"
+                    style="padding-right:10px;padding-bottom:5px;">
+                    <span i18n:translate="">Remarks:</span>&nbsp;
+                    <textarea
+                        style="width:100%;display:block;"
+                        autocomplete="off"
+                        rows="1"
+                        tal:content="python:item.get('Remarks','')"
+                        tal:condition="python:remarksedit==True"
+                        tal:attributes="
+                            class python:'listing_remarks';
+                            uid string:${item/uid};
+                            as_uid string:${item/service_uid|nothing};
+                            st_uid string:${item/st_uid|nothing};
+                            objectId string:${item/id};
+                            name string:Remarks.${item/uid}:records;
+                            value python:item.get('Remarks', '');"></textarea>
+                    <span
+                        autocomplete="off"
+                        tal:condition="python:remarksedit==False"
+                        tal:attributes="
+                            class python:'listing_remarks';
+                            name string:Remarks.${item/uid}:records;"
+                        tal:content="python:item.get('Remarks', '') if hasremarks else 'No Remarks.'"/>
+                </td>
+            </tr>
+        </tal:remarks_condition>
 
-</tal:get_colspan>
+    </tal:get_colspan>
 
 </tal:items>


### PR DESCRIPTION
Actually: indentation + important commented code in manage analyses.

Ok, this PR is scary, modifying "bika_listing_table_items.pt" could be a terrible thing since all system views depends on it. BUT without proper indentation, debugging or modifying or working on it becomes difficult.

The issue I was working on has something to do with this file, so I visualised a good chance to intendate the file. Only indentation changes. Latter I will create a new PR with the bug fix. 

I prefered this way in order to make life easier for the reviewer of my code.

RE the comment, it was deleted in a previous PR, but we need it here since it brokes a functionality: In Manage Analyses view, analyses in states further than received, should not be deleted from their Analysis Request. Consequently they shouldn't be editable in Manage Analyses view. That piece of code allows that functionality, but it was commented for performance issues, since we were forced to get the whole archetype object to check its state.