### PR TITLE
Reflex Rules don't have 'inactive_state' values set. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -69,6 +69,7 @@ Changelog
 - #364 Error on Manage Results view while Adding new Analyses from different Category
 - #365 Lims Installation fails during setting client permissions in bika setup.
 - #358 Merged updates for AR Add2
+- #371 Reflex Rules don't have 'inactive_state' values set.
 
 
 1.0.0 (2017-10-13)

--- a/bika/lims/controlpanel/bika_instruments.py
+++ b/bika/lims/controlpanel/bika_instruments.py
@@ -113,7 +113,6 @@ class InstrumentsView(BikaListingView):
             if not data:
                 items[x]['ExpiryDate'] = _("No date set")
             else:
-                import pdb;pdb.set_trace()
                 items[x]['ExpiryDate'] = data.asdatetime().strftime(self.date_format_short)
 
             if obj.isOutOfDate():

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1.1.3</version>
+  <version>1.1.4</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/profiles/default/workflows.xml
+++ b/bika/lims/profiles/default/workflows.xml
@@ -406,6 +406,11 @@
       <bound-workflow workflow_id="bika_inactive_workflow"/>
     </type>
 
+    <!-- Reflex Rules -->
+    <type type_id="ReflexRule">
+      <bound-workflow workflow_id="bika_inactive_workflow"/>
+    </type>
+
     <!-- Reject Analysis -->
     <type type_id="RejectAnalysis">
       <bound-workflow workflow_id="bika_reject_analysis_workflow"/>

--- a/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/reflexrulewidget.js
@@ -564,6 +564,9 @@ jQuery(function($){
      */
     function setup_svof(setupdata){
         var rules = setupdata.saved_actions.rules;
+        if(!rules || rules.length==0){
+            return;
+        }
         var rulescontainers = $('td.rulescontainer');
 
         $.each(rulescontainers,function(index1, element1){
@@ -591,6 +594,9 @@ jQuery(function($){
      */
     function setup_worksheettemplate(setupdata){
         var rules = setupdata.saved_actions.rules;
+        if(!rules || rules.length==0){
+            return;
+        }
         var rulescontainers = $('td.rulescontainer');
         $.each(rulescontainers,function(index1, element1){
             var wsts = $(element1).find('select[id^="ReflexRules-worksheettemplate-"]');

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -45,4 +45,11 @@
        handler="bika.lims.upgrade.v01_01_003.upgrade"
        profile="bika.lims:default"/>
 
+ <genericsetup:upgradeStep
+       title="Upgrade to Bika LIMS Evo 1.1.4"
+       source="1.1.3"
+       destination="1.1.4"
+       handler="bika.lims.upgrade.v01_01_004.upgrade"
+       profile="bika.lims:default"/>
+
 </configure>

--- a/bika/lims/upgrade/v01_01_004.py
+++ b/bika/lims/upgrade/v01_01_004.py
@@ -1,12 +1,13 @@
 from Acquisition import aq_inner
 from Acquisition import aq_parent
 from Products.CMFCore.utils import getToolByName
+from bika.lims import api
 from bika.lims import logger
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
 
-version = '1.1.3'
+version = '1.1.4'
 profile = 'profile-{0}:default'.format(product)
 
 
@@ -26,10 +27,28 @@ def upgrade(tool):
 
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
-    # Attachments must be present in a catalog, otherwise the idserver
-    # will fall apart.  https://github.com/senaite/bika.lims/issues/323
-    at = getToolByName(portal, 'archetype_tool')
-    at.setCatalogsByType('Attachment', ['portal_catalog'])
+    # Add inactive_state workflow for Reflex Rules
+    setup.runImportStepFromProfile(profile, 'workflow')
+    update_reflexrules_workflow_state(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
     return True
+
+
+def update_reflexrules_workflow_state(portal):
+    """
+    Updates Reflex Rules' inactive_state, otherwise they don't have it by
+    default.
+    :param portal: Portal object
+    :return: None
+    """
+    wf_tool = getToolByName(portal, 'portal_workflow')
+    logger.info("Updating Reflex Rules' 'inactive_state's...")
+    wf = wf_tool.getWorkflowById("bika_inactive_workflow")
+    uc = api.get_tool('portal_catalog')
+    r_rules = uc(portal_type='ReflexRule')
+    for rr in r_rules:
+        obj = rr.getObject()
+        wf.updateRoleMappingsFor(obj)
+        obj.reindexObject()
+    logger.info("Reflex Rules' 'inactive_state's were updated.")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@
 
 from setuptools import setup, find_packages
 
-version = '1.1.3'
+version = '1.1.4'
 
 setup(name='bika.lims',
       version=version,


### PR DESCRIPTION
**Current Behavior**
When a Reflex Rule is created, it doesn't have any 'inactive_state' value, and thus, filtering by `review_states` doesn't work. Also since `inactive_state` is not _active_, Reflex Rule is never applied.

**Expected Behavior after this PR**
Filtering by review_state works properly in Reflex Rules listing.
Reflex Rules are applied if conditions meet.