### PR TITLE
Dependencies error in Manage Analyses view

### DIFF
--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -236,7 +236,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
             item['before']['Price'] = symbol
             item['Price'] = obj.getPrice()
             item['class']['Price'] = 'nowrap'
-
+            item['allow_edit'] = list()
             if item['selected']:
                 item['allow_edit'] = ['Partition', 'min', 'max', 'error']
                 if not logged_in_client(self.context):
@@ -302,7 +302,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
             # Display analyses for this Analysis Service in results?
             ser = self.context.getAnalysisServiceSettings(obj.UID())
-            item['allow_edit'] = ['Hidden', ]
+            item['allow_edit'].append('Hidden')
             item['Hidden'] = ser.get('hidden', obj.getHidden())
             item['Unit'] = obj.getUnit()
 

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -7,6 +7,11 @@ import json
 
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from plone.app.content.browser.interfaces import IFolderContentsView
+from plone.app.layout.globals.interfaces import IViewView
+from zope.i18n.locales import locales
+from zope.interface import implements
+
 from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
@@ -14,10 +19,7 @@ from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.browser.sample import SamplePartitionsView
 from bika.lims.utils import dicts_to_dict, t
 from bika.lims.utils import logged_in_client
-from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.layout.globals.interfaces import IViewView
-from zope.i18n.locales import locales
-from zope.interface import implements
+from bika.lims.workflow import wasTransitionPerformed
 
 
 class AnalysisRequestAnalysesView(BikaListingView):
@@ -224,11 +226,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
             item['selected'] = item['uid'] in self.selected
             item['class']['Title'] = 'service_title'
-
-            # js checks in row_data if an analysis may be removed.
-            row_data = {}
-            item['row_data'] = json.dumps(row_data)
-
+            row_data = dict()
             calculation = obj.getCalculation()
             item['Calculation'] = calculation and calculation.Title()
 
@@ -249,6 +247,10 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
             if obj.UID() in self.analyses:
                 analysis = self.analyses[obj.UID()]
+
+                row_data['disabled'] = wasTransitionPerformed(
+                    analysis, 'submit')
+
                 part = analysis.getSamplePartition()
                 part = part and part or obj
                 item['Partition'] = part.Title()
@@ -264,6 +266,8 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 item["max"] = ''
                 item["error"] = ''
 
+            # js checks in row_data if an analysis may not be editable.
+            item['row_data'] = json.dumps(row_data)
             after_icons = ''
             if obj.getAccredited():
                 after_icons += "<img\

--- a/bika/lims/browser/js/bika.lims.analysisrequest.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.js
@@ -545,7 +545,11 @@ function AnalysisRequestAnalysesView() {
     */
     function check_service(service_uid){
         var new_element, element;
-
+        // Check if allow_edit is enable
+        var row_data = $.parseJSON($("#"+service_uid+"_row_data").val());
+        if (row_data.disabled === true){
+            return
+        };
         // Add partition dropdown
         element = $("[name='Partition."+service_uid+":records']");
         new_element = "" +

--- a/bika/lims/browser/js/bika.lims.analysisrequest.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.js
@@ -545,7 +545,14 @@ function AnalysisRequestAnalysesView() {
     */
     function check_service(service_uid){
         var new_element, element;
-        // Check if allow_edit is enable
+        /* Check if this row is disabled. row_data has the attribute "disabled"
+        as true if the analysis service has been submitted. So, in this case
+        no further action will take place.
+
+        "allow_edit" attribute in bika_listing displays the editable fields.
+        Since the object keeps this attr even if the row is disabled; price,
+        partition, min,max and error will be displayed (but disabled).
+        */
         var row_data = $.parseJSON($("#"+service_uid+"_row_data").val());
         if (row_data.disabled === true){
             return


### PR DESCRIPTION
Issue: https://github.com/senaite/bika.lims/issues/357

- Only "hidden" field was editable
- Disable Analysis Services edition if it has been submitted: In Manage Analyses view, analyses in states further than submited should not be deleted from their Analysis Request. Consequently they shouldn't be editable in Manage Analyses view.