### PR TITLE
Fix 'ClientWorkflowAction' object has no attribute 'portal_url' when publishing multiple ARs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,7 @@ Changelog
 
 **Fixed**
 
+- #387 ClientWorkflowAction object has no attribute 'portal_url' when publishing multiple ARs
 - #386 PR-2313 UniqueFieldValidator: Encode value to utf-8 before passing it to the catalog
 - #386 PR-2312 IDServer: Fixed default split length value
 - #386 PR-2311 Fix ID Server to handle a flushed storage or existing IDs with the same prefix

--- a/bika/lims/browser/client/workflow.py
+++ b/bika/lims/browser/client/workflow.py
@@ -202,11 +202,12 @@ class ClientWorkflowAction(AnalysisRequestWorkflowAction):
             its = []
             for uid, obj in objects.items():
                 if isActive(obj):
-                    its.append(uid);
+                    its.append(uid)
             its = ",".join(its)
             q = "/publish?items=" + its
-            dest = self.portal_url+"/analysisrequests" + q
-            self.request.response.redirect(dest)
+            self.destination_url = self.request.get_header(
+                "referer", self.context.absolute_url()) + q
+            self.request.response.redirect(self.destination_url)
 
         else:
             AnalysisRequestWorkflowAction.__call__(self)


### PR DESCRIPTION
Fixes the following when trying to publish several ARs at the same time from Client's Analysis Request list

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.client.workflow, line 208, in __call__
AttributeError: 'ClientWorkflowAction' object has no attribute 'portal_url'
```