### PR TITLE
Fix Unable to get the portal object when digesting/creation the results report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,7 @@ Changelog
 
 **Fixed**
 
+- #388 Unable to get the portal object when digesting/creating results report
 - #387 ClientWorkflowAction object has no attribute 'portal_url' when publishing multiple ARs
 - #386 PR-2313 UniqueFieldValidator: Encode value to utf-8 before passing it to the catalog
 - #386 PR-2312 IDServer: Fixed default split length value

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -26,7 +26,6 @@ from Products.CMFPlone.utils import _createObjectByType, safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from bika.lims import POINTS_OF_CAPTURE, bikaMessageFactory as _, t
 from bika.lims import logger
-from bika.lims.api import get_tool
 from bika.lims.browser import BrowserView, ulocalized_time
 from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.idserver import renameAfterCreation
@@ -1278,7 +1277,7 @@ class AnalysisRequestDigester:
         workflow = getToolByName(self.context, 'portal_workflow')
         showhidden = self.isHiddenAnalysesVisible()
 
-        catalog = get_tool(CATALOG_ANALYSIS_LISTING)
+        catalog = getToolByName(self.context, CATALOG_ANALYSIS_LISTING)
         brains = catalog({'getRequestUID': ar.UID(),
                           'review_state': analysis_states,
                           'sort_on': 'sortable_title'})


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/xispa/buildout-cache/eggs/Zope2-2.13.24-py2.7.egg/ZServer/PubCore/ZServerPublisher.py", line 31, in __init__
    response=b)
  File "/xispa/buildout-cache/eggs/Zope2-2.13.24-py2.7.egg/ZPublisher/Publish.py", line 455, in publish_module
    environ, debug, request, response)
  File "/xispa/buildout-cache/eggs/Zope2-2.13.24-py2.7.egg/ZPublisher/Publish.py", line 276, in publish_module_standard
    if request is not None: request.close()
  File "/xispa/buildout-cache/eggs/Zope2-2.13.24-py2.7.egg/ZPublisher/BaseRequest.py", line 220, in close
    notify(EndRequestEvent(None, self))
  File "/xispa/buildout-cache/eggs/zope.event-3.5.2-py2.7.egg/zope/event/__init__.py", line 31, in notify
    subscriber(event)
  File "/xispa/buildout-cache/eggs/zope.component-3.9.5-py2.7.egg/zope/component/event.py", line 24, in dispatch
    zope.component.subscribers(event, None)
  File "/xispa/buildout-cache/eggs/zope.component-3.9.5-py2.7.egg/zope/component/_api.py", line 136, in subscribers
    return sitemanager.subscribers(objects, interface)
  File "/xispa/buildout-cache/eggs/zope.component-3.9.5-py2.7.egg/zope/component/registry.py", line 321, in subscribers
    return self.adapters.subscribers(objects, provided)
  File "/xispa/buildout-cache/eggs/zope.interface-3.6.7-py2.7-linux-x86_64.egg/zope/interface/adapter.py", line 585, in subscribers
    subscription(*objects)
  File "/xispa/zinstance/src/bika.lims/bika/lims/browser/analysisrequest/publish.py", line 1536, in EndRequestHandler
    digester(ar, overwrite=True)
  File "/xispa/zinstance/src/bika.lims/bika/lims/browser/analysisrequest/publish.py", line 753, in __call__
    data = self._ar_data(ar)
  File "/xispa/zinstance/src/bika.lims/bika/lims/browser/analysisrequest/publish.py", line 967, in _ar_data
    data['analyses'] = self._analyses_data(ar, ['verified', 'published'])
  File "/xispa/zinstance/src/bika.lims/bika/lims/browser/analysisrequest/publish.py", line 1281, in _analyses_data
    catalog = get_tool(CATALOG_ANALYSIS_LISTING)
  File "/xispa/zinstance/src/bika.lims/bika/lims/api.py", line 183, in get_tool
    return ploneapi.portal.get_tool(name)
  File "<string>", line 2, in get_tool
  File "/xispa/buildout-cache/eggs/plone.api-1.8.1-py2.7.egg/plone/api/validation.py", line 77, in wrapped
    return function(*args, **kwargs)
  File "/xispa/buildout-cache/eggs/plone.api-1.8.1-py2.7.egg/plone/api/portal.py", line 118, in get_tool
    return getToolByName(get(), name)
  File "/xispa/buildout-cache/eggs/plone.api-1.8.1-py2.7.egg/plone/api/portal.py", line 82, in get
    'Unable to get the portal object.
```