### PR TITLE
Remove log verbosity of UIDReference.get when value is None or empty

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ Changelog
 
 **Fixed**
 
-
+- #390 Remove log verbosity of UIDReference.get when value is None or empty
 
 **Security**
 

--- a/bika/lims/browser/fields/uidreferencefield.py
+++ b/bika/lims/browser/fields/uidreferencefield.py
@@ -101,6 +101,8 @@ class UIDReferenceField(StringField):
         :rtype: BaseContent | list[BaseContent]
         """
         value = StringField.get(self, context, **kwargs)
+        if not value:
+            return [] if self.multiValued else None
         if self.multiValued:
             # Only return objects which actually exist; this is necessary here
             # because there are no HoldingReferences. This opens the
@@ -125,6 +127,8 @@ class UIDReferenceField(StringField):
         :rtype: string | list[string]
         """
         value = StringField.get(self, context, **kwargs)
+        if not value:
+            return [] if self.multiValued else None
         if self.multiValued:
             ret = value
         else:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`UIDReferenceField.get` tries to fetch the object also if the value stored in the field is empty or None. This causes a lot of verbosity in the logs as if were errors, but are not, e.g.:

```
2017-11-20 16:43:03 ERROR Bika <Analysis at Zn>.Instrument: Resolving UIDReference failed for .  No object will be returned.
2017-11-20 16:43:03 ERROR Bika <Analysis at Zn>.Method: Resolving UIDReference failed for .  No object will be returned.
2017-11-20 16:43:03 ERROR Bika <Analysis at Zn>.Method: Resolving UIDReference failed for .  No object will be returned.
2017-11-20 16:43:03 ERROR Bika <Analysis at Zn>.Method: Resolving UIDReference failed for .  No object will be returned.
2017-11-20 16:43:03 ERROR Bika <Analysis at Zn>.Instrument: Resolving UIDReference failed for .  No object will be returned.
```

## Current behavior before PR

A lot of false errors appear in the log when calling a `UIDReferenceField`'s `get` function if the field has no value (or is empty if multivalued) .

## Desired behavior after PR is merged

No false-errors in the log.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
