### PR TITLE
PR2138 AR Add Form: Pass error messages to the frontend

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Fixed**
 
+- #399 PR-2318 AR Add fails silently if e.g. the ID of the AR was already taken
 
 
 **Security**

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1647,7 +1647,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         # extract records from request
         records = self.get_records()
 
-        errors = {}
+        fielderrors = {}
+        errors = {"message": "", "fielderrors": {}}
+
         attachments = {}
         valid_records = []
 
@@ -1702,7 +1704,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             for field in missing:
                 fieldname = "{}-{}".format(field, n)
                 msg = _("Field '{}' is required".format(field))
-                errors[fieldname] = msg
+                fielderrors[fieldname] = msg
 
             # Selected Analysis UIDs
             selected_analysis_uids = record.get("Analyses", [])
@@ -1758,7 +1760,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # append the valid record to the list of valid records
             valid_records.append(valid_record)
 
-        if errors:
+        # return immediately with an error response if some field checks failed
+        if fielderrors:
+            errors["fielderrors"] = fielderrors
             return {'errors': errors}
 
         # Process Form
@@ -1774,12 +1778,11 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             specifications = record.pop("Specifications", {})
 
             # Create the Analysis Request
-            ar = crar(
-                client,
-                self.request,
-                record,
-                specifications=specifications,
-            )
+            try:
+                ar = crar(client, self.request, record, specifications=specifications)
+            except (KeyError, RuntimeError) as e:
+                errors["message"] = e.message
+                return {"errors": errors}
             ARs.append(ar.Title())
 
             _attachments = []

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1328,14 +1328,17 @@
          */
         var ars, destination, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
         if (data['errors']) {
-          msg = '';
-          for (fieldname in data.errors) {
+          msg = data.errors.message;
+          if (msg !== "") {
+            msg = msg + "<br/>";
+          }
+          for (fieldname in data.errors.fielderrors) {
             field = $("#" + fieldname);
             parent = field.parent("div.field");
             if (field && parent) {
               parent.toggleClass("error");
               errorbox = parent.children("div.fieldErrorBox");
-              message = data.errors[fieldname];
+              message = data.errors.fielderrors[fieldname];
               errorbox.text(message);
               msg += message + "<br/>";
             }

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1447,14 +1447,17 @@ class window.AnalysisRequestAdd
       ###
 
       if data['errors']
-        msg = ''
-        for fieldname of data.errors
+        msg = data.errors.message
+        if msg isnt ""
+          msg = "#{msg}<br/>"
+
+        for fieldname of data.errors.fielderrors
           field = $("##{fieldname}")
           parent = field.parent "div.field"
           if field and parent
             parent.toggleClass "error"
             errorbox = parent.children("div.fieldErrorBox")
-            message = data.errors[fieldname]
+            message = data.errors.fielderrors[fieldname]
             errorbox.text message
             msg += "#{message}<br/>"
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

No error message is shown in the AR Add Form
Ports https://github.com/bikalims/bika.lims/pull/2318

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
