### PR TITLE
PR-2319 Skip Analyses in disabled categories

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Changelog
 
 **Fixed**
 
+- #400 PR-2319 AR Add fails if an Analysis Category was disabled
 
 
 **Security**

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -506,7 +506,8 @@ class AnalysisRequestAddView(BrowserView):
 
         for brain in services:
             category = brain.getCategoryTitle
-            analyses[category].append(brain)
+            if category in analyses:
+                analyses[category].append(brain)
         return analyses
 
     @cache(cache_key)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

AR Add form fails if an Analysis Category was disabled
Ports https://github.com/bikalims/bika.lims/pull/2319

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
