### PR TITLE
PR2321 AR Add Copy of multiple ARs from different clients raises a Traceback in the background

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Changelog
 
 **Changed**
 
+- #401 PR-2321 AR Add Copy of multiple ARs from different clients raises a Traceback in the background
 
 
 **Fixed**

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1084,7 +1084,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # client
         client = self.get_client()
-        client_uid = api.get_uid(client) if client else ""
+        client_uid = client and api.get_uid(client) or ""
 
         # sample matrix
         sample_matrix = obj.getSampleMatrix()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

AR Add Copy of multiple ARs from different clients raises a Traceback in the background
Ports https://github.com/bikalims/bika.lims/pull/2321

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
