### PR TITLE
Sort Analysis Services correctly based on their Sortkey + Title (Again)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changelog
 
 **Fixed**
 
+- #402 Sort Analysis Services correctly based on their Sortkey + Title (Again)
 - #399 PR-2318 AR Add fails silently if e.g. the ID of the AR was already taken
 - #400 PR-2319 AR Add fails if an Analysis Category was disabled
 - #401 PR-2321 AR Add Copy of multiple ARs from different clients raises a Traceback in the background

--- a/bika/lims/controlpanel/bika_analysisservices.py
+++ b/bika/lims/controlpanel/bika_analysisservices.py
@@ -152,7 +152,7 @@ class AnalysisServicesView(BikaListingView):
         self.show_select_column = True
         self.show_select_all_checkbox = False
         self.pagesize = 25
-        self.sort_on = 'sortable_title'
+        self.sort_on = 'Title'
         self.categories = []
         self.do_cats = self.context.bika_setup.getCategoriseAnalysisServices()
         if self.do_cats:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The Analysis Services list is not sorted by SortKey + Title by default.
Linked issue: https://github.com/senaite/bika.lims/issues/

## Current behavior before PR

The Analysis Services list is not sorted by SortKey + Title by default.

## Desired behavior after PR is merged

The Analysis Services list is sorted by Sortkey + Title by default as described in https://github.com/senaite/bika.lims/pull/307 and https://github.com/senaite/bika.lims/pull/362

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
