### PR TITLE
Calculations not triggered in manage results view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Changelog
 
 **Fixed**
 
+- #403 Calculations not triggered in manage results view
 - #399 PR-2318 AR Add fails silently if e.g. the ID of the AR was already taken
 - #400 PR-2319 AR Add fails if an Analysis Category was disabled
 - #401 PR-2321 AR Add Copy of multiple ARs from different clients raises a Traceback in the background

--- a/bika/lims/browser/fields/historyawarereferencefield.py
+++ b/bika/lims/browser/fields/historyawarereferencefield.py
@@ -72,6 +72,7 @@ class HistoryAwareReferenceField(ReferenceField):
         add = [v for v in uids if v and v not in targetUIDs]
 
         newuids = [t for t in list(targetUIDs) + list(uids) if t not in sub]
+        newuids = list(set(newuids))
         for uid in newuids:
             # update version_id of all existing references that aren't
             # about to be removed anyway (contents of sub)

--- a/bika/lims/content/calculation.py
+++ b/bika/lims/content/calculation.py
@@ -189,15 +189,11 @@ class Calculation(BaseFolder, HistoryAwareMixin):
             self.setDependentServices(None)
             self.getField('Formula').set(self, Formula)
         else:
-            DependentServices = []
             keywords = re.compile(r"\[([^.^\]]+)\]").findall(Formula)
-            for keyword in keywords:
-                service = bsc(portal_type="AnalysisService",
-                              getKeyword=keyword)
-                if service:
-                    DependentServices.append(service[0].getObject())
-
-            self.getField('DependentServices').set(self, DependentServices)
+            brains = bsc(portal_type='AnalysisService',
+                         getKeyword=keywords)
+            services = [brain.getObject() for brain in brains]
+            self.getField('DependentServices').set(self, services)
             self.getField('Formula').set(self, Formula)
 
     def getMinifiedFormula(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Calculations for old Analysis Requests were not triggered
Issue: https://github.com/senaite/bika.lims/issues/355

## Current behavior before PR

Calculations in manage results for analyses from old ARs, created before Nov 2 2017, were not triggered when typing the results in dependent analyses. 

## Desired behavior after PR is merged

Calculations for analyses from ARs that were created before Nov 2 2017 are triggered normally.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
