### PR TITLE
Analyses don't get selected when copying an Analysis Request without profiles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #411 Analyses don't get selected when copying an Analysis Request without profiles
 
 **Security**
 

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -515,7 +515,7 @@ class AnalysisRequestAddView(BrowserView):
         """Return the service from the analysis
         """
         analysis = api.get_object(analysis)
-        return api.get_uid(analysis.getService())
+        return api.get_uid(analysis.getAnalysisService())
 
     def get_calculation_dependencies_for(self, service):
         """Calculation dependencies of this service and the calculation of each


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Analyses don't get selected when copying an AR that was created without profiles or templates assigned. This bad behavior is because of the architectural changes done in AnalysisService + Analysis . When an Analysis is created using an Analysis Service as a source, all field values are copied to the new Analysis and the link with the parent is no longer maintained, so there is no need of `HistoryReferenceField` and the system behaves better. As a result, the [`getService` function was flagged as `deprecated` and returns the same Analysis object (not the AnalysisService)](https://github.com/senaite/bika.lims/blob/master/bika/lims/content/abstractanalysis.py#L155-L159). Add2 was still using this function to get the Analysis Service UID used to create the Analysis.
Linked issue: [AR copy without analysis services](https://github.com/senaite/bika.lims/issues/407)

## Current behavior before PR

Analyses don't get selected in AR Add2 view when copying an AR that was created without profiles or templates assigned.

## Desired behavior after PR is merged

Analyses get selected in AR Add2 view when copying an Analysis Request that was created without profiles or templates assigned.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
