### PR TITLE
Referencefield JS UID check: Don't remove Profile UIDs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #415 Referencefield JS UID check: Don't remove Profile UIDs
 - #411 Analyses don't get selected when copying an Analysis Request without profiles
 
 **Security**

--- a/bika/lims/skins/bika/bika_widgets/referencewidget.js
+++ b/bika/lims/skins/bika/bika_widgets/referencewidget.js
@@ -216,6 +216,12 @@ function check_missing_UID(){
 	*/
 	$.each($(".ArchetypesReferenceWidget").children("input.referencewidget"),
 		function (index, field) {
+      // None of this stuff should take effect for multivalued widgets;
+      // Right now, these must take care of themselves.
+      var multiValued = $(this).attr("multiValued") == "1";
+      if(multiValued){
+        return;
+      }
 			var fieldName = $(this).attr("name");
 			// uid attr of text input
 			var uid = $(this).attr("uid");


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/412

## Current behavior before PR

Profile UIDs get flushed on AR copy.

## Desired behavior after PR is merged

Profile UIDs are preserved on AR copy

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
