### PR TITLE
Insufficient privileges labclerk

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Changelog
 
 **Fixed**
 
+- #418 LabClerks don't have access to AR view after received and before verified
 - #415 Referencefield JS UID check: Don't remove Profile UIDs
 - #411 Analyses don't get selected when copying an Analysis Request without profiles
 

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -87,7 +87,7 @@ class AnalysisRequestsView(BikaListingView):
             'getId': {
                 'title': _('Request ID'),
                 'attr': 'getId',
-                'replace_url': 'absolute_url',
+                'replace_url': 'getURL',
                 'index': 'getId'},
             'getClientOrderNumber': {
                 'title': _('Client Order'),
@@ -865,10 +865,6 @@ class AnalysisRequestsView(BikaListingView):
         priority_text = PRIORITIES.getValue(priority)
         priority_div = '<div class="priority-ico priority-%s"><span class="notext">%s</span><div>'
         item['replace']['Priority'] = priority_div % (priority, priority_text)
-        item['getId'] = obj.getId
-        url = obj.getURL() + "?check_edit=1"
-        item['replace']['getId'] = "<a href='%s'>%s</a>" % \
-            (url, item['getId'])
         item['replace']['getProfilesTitle'] =\
             ", ".join(obj.getProfilesTitleStr)
 

--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -4,7 +4,8 @@
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 from AccessControl import getSecurityManager
-from bika.lims import bikaMessageFactory as _
+from AccessControl.security import checkPermission
+from bika.lims import bikaMessageFactory as _, api
 from bika.lims.utils import t
 from bika.lims.browser import BrowserView
 from bika.lims.browser.analyses import AnalysesView
@@ -15,7 +16,7 @@ from bika.lims.config import POINTS_OF_CAPTURE
 from bika.lims.permissions import *
 from bika.lims.utils import isActive
 from bika.lims.utils import to_utf8
-from bika.lims.workflow import doActionFor
+from bika.lims.workflow import doActionFor, wasTransitionPerformed
 from DateTime import DateTime
 from bika.lims.workflow import doActionFor
 from plone.app.layout.globals.interfaces import IViewView
@@ -37,23 +38,31 @@ class AnalysisRequestViewView(BrowserView):
     messages = []
 
     def __init__(self, context, request):
-        super(AnalysisRequestViewView, self).__init__(context, request)
+        self.init__ = super(AnalysisRequestViewView, self).__init__(context,
+                                                                    request)
         self.icon = self.portal_url + "/++resource++bika.lims.images/analysisrequest_big.png"
         self.messages = []
 
     def __call__(self):
         ar = self.context
-        if 'check_edit' in self.request and\
-                self.request.get('check_edit') == '1':
-                # Another check, here to increase performance, is it stupid?
-                state = ar.getObjectWorkflowStates().get('review_state', '')
-                if state in ['to_be_verified', 'sample_received']:
-                    # It mens we should redirect to manage_results
-                    redirect = self.context.absolute_url() + '/manage_results'
-                    self.request.response.redirect(redirect)
         workflow = getToolByName(self.context, 'portal_workflow')
         if 'transition' in self.request.form:
             doActionFor(self.context, self.request.form['transition'])
+
+        # If the analysis request has been received and hasn't been yet
+        # verified yet, redirect the user to manage_results view, but only if
+        # the user has privileges to Edit(Field)Results, cause otherwise she/he
+        # will receive an InsufficientPrivileges error!
+        mtool = api.get_tool('portal_membership')
+        if (mtool.checkPermission(EditResults, self.context) and
+            mtool.checkPermission(EditFieldResults, self.context) and
+            wasTransitionPerformed(self.context, 'receive') and
+            not wasTransitionPerformed(self.context, 'verify')):
+            # Redirect to manage results view
+            manage_results_url = self.context.absolute_url() + '/manage_results'
+            self.request.response.redirect(manage_results_url)
+            return
+
         # Contacts get expanded for view
         contact = self.context.getContact()
         contacts = []

--- a/bika/lims/browser/js/bika.lims.analysisrequest.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.js
@@ -145,7 +145,7 @@ function AnalysisRequestViewView() {
                         // Getting the url like that will return the query
                         // part of it:
                         // http://localhost:8080/Plone/clients/client17-14/..
-                        //    ..OA17-0030-R01?check_edit=1
+                        //    ..OA17-0030-R01
                         // In order to create a correct ajax call
                         // we only need until the pathname of that url:
                         // http://localhost:8080/Plone/clients/client17-14/..
@@ -333,9 +333,7 @@ function AnalysisRequestViewView() {
          * @requestdata should has the format  {fieldname=fieldvalue} ->  { ReportDryMatter=false}.
          */
         var url = window.location.href
-            .replace('/base_view', '')
-            .replace('?check_edit=1', '')
-            .replace('?check_edit=0', '');
+            .replace('/base_view', '');
         var obj_path = url.replace(window.portal_url, '');
         // Staff for the notification
         var element,name = $.map(requestdata, function(element,index) {return element, index});

--- a/bika/lims/browser/js/bika.lims.rejection.js
+++ b/bika/lims/browser/js/bika.lims.rejection.js
@@ -132,8 +132,6 @@
             .replace('/analyses', '')
             .replace('/manage_results', '')
             .replace('/not_requested', '')
-            .replace('?check_edit=1', '')
-            .replace('?check_edit=0', '')
             .replace('/log', '');
          var obj_path = url.replace(window.portal_url, '');
          var redirect_state = $("a#workflow-transition-reject").attr('href');


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Lab Clerks don't have access to Analysis Request view when they click to the link displayed in AR list. The reason is that if the Analysis Request is received and not verified, the system redirects the user to the manage_results view from the AR, for which LabClerks do not have privileges. For achieving this, a workaround with a `check_edit` param in the request was used. With this Pull Request, the functionality is preserved, but `check_edit` tweak has been removed and in the `__call__` view of  `AnalysisRequestView` the permissions and status of the AR are checked, so if the current user has no privileges to Edit(Field)Results, the default AR view will be displayed.

## Current behavior before PR

LabClerks cannot access to ARs because the system redirects them to AR's manage_results view

## Desired behavior after PR is merged

LabClerks can access to AR view.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
