### PR TITLE
'getLastVerificator' function of Abstract Analyses fails when there is no Verificator.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,7 @@ Changelog
 
 **Fixed**
 
+- #419 'getLastVerificator' function of Abstract Analyses fails when there is no Verificator.
 - #388 Unable to get the portal object when digesting/creating results report
 - #387 ClientWorkflowAction object has no attribute 'portal_url' when publishing multiple ARs
 - #386 PR-2313 UniqueFieldValidator: Encode value to utf-8 before passing it to the catalog

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -183,21 +183,28 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
     @security.public
     def deleteLastVerificator(self):
-        verificators = self.getVerificators().split(',')
+        verificators_str = self.getVerificators()
+        if not verificators_str:
+            return
+        verificators = verificators_str.split(',')
         del verificators[-1]
         self.setVerificators(",".join(verificators))
         self.reindexObject()
 
     @security.public
     def wasVerifiedByUser(self, username):
-        verificators = self.getVerificators().split(',')
+        verificators_str = self.getVerificators()
+        if not verificators_str:
+            return False
+        verificators = verificators_str.split(',')
         return username in verificators
 
     @security.public
     def getLastVerificator(self):
-        if not self.getVerificators():
+        verificators = self.getVerificators()
+        if not verificators:
             return None
-        return self.getVerificators().split(',')[-1]
+        return verificators.split(',')[-1]
 
     @security.public
     def setVerificator(self, value):

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -195,6 +195,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
 
     @security.public
     def getLastVerificator(self):
+        if not self.getVerificators():
+            return None
         return self.getVerificators().split(',')[-1]
 
     @security.public


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

`getLastVerificator` function of Abstract Analyses fails when there is no _Verificator_.

## Current behavior before PR
`getLastVerificator` function causes an error when `getVerificators` return `None`.
## Desired behavior after PR is merged

`getLastVerificator` returns `None` when there is no _Verificator_.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
