### PR TITLE
Fixed computed field of AR profiles for correct listing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #425 AR Listing View: Analysis profiles rendering error
 - #420 Searches by term with custom indexes do not work in clients folder view
 - #410 Unable to select or deselect columns to be displayed in lists
 - #409 In Add Analyses view, analyses id are displayed instead of Analysis Request IDs

--- a/bika/lims/browser/analysisrequest/analysisrequests.py
+++ b/bika/lims/browser/analysisrequest/analysisrequests.py
@@ -865,8 +865,7 @@ class AnalysisRequestsView(BikaListingView):
         priority_text = PRIORITIES.getValue(priority)
         priority_div = '<div class="priority-ico priority-%s"><span class="notext">%s</span><div>'
         item['replace']['Priority'] = priority_div % (priority, priority_text)
-        item['replace']['getProfilesTitle'] =\
-            ", ".join(obj.getProfilesTitleStr)
+        item['replace']['getProfilesTitle'] = obj.getProfilesTitleStr
 
         analysesnum = obj.getAnalysesNum
         if analysesnum:

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -1703,7 +1703,7 @@ schema = BikaSchema.copy() + Schema((
     ),
     ComputedField(
         'ProfilesTitleStr',
-        expression="' '.join([p.Title() for p in here.getProfiles()]) if here.getProfiles() else []",
+        expression="', '.join([p.Title() for p in here.getProfiles()]) if here.getProfiles() else ''",
         widget=ComputedWidget(visible=False),
     ),
     ComputedField(

--- a/bika/lims/upgrade/v01_01_007.py
+++ b/bika/lims/upgrade/v01_01_007.py
@@ -1,4 +1,5 @@
 from bika.lims import logger
+from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
@@ -20,6 +21,7 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
+    ut.cleanAndRebuildCatalog(CATALOG_ANALYSIS_REQUEST_LISTING)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/425

## Current behavior before PR

Profile(s) in AR listings are splitted within their titles.

## Desired behavior after PR is merged

Profile(s) in AR listings are splitted and comma separated correctly.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
