### PR TITLE
Fixed (Pre-)Publish Action from Client AR listings

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #428 AR Publication from Client Listing does not work
 - #420 Searches by term with custom indexes do not work in clients folder view
 - #410 Unable to select or deselect columns to be displayed in lists
 - #409 In Add Analyses view, analyses id are displayed instead of Analysis Request IDs

--- a/bika/lims/browser/analysisrequest/configure.zcml
+++ b/bika/lims/browser/analysisrequest/configure.zcml
@@ -234,6 +234,14 @@
       layer="bika.lims.interfaces.IBikaLIMS"
   />
 
+  <browser:page
+      for="bika.lims.interfaces.IClient"
+      name="publish"
+      class="bika.lims.browser.analysisrequest.publish.AnalysisRequestPublishView"
+      permission="bika.lims.ManageAnalysisRequests"
+      layer="bika.lims.interfaces.IBikaLIMS"
+  />
+
   <!-- Verifying any Analysis will cause a digestion of the parent AR to
   be triggered at the end of the request -->
   <subscriber

--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -86,7 +86,7 @@ class AnalysisRequestPublishView(BrowserView):
     def __call__(self):
         if self.context.portal_type == 'AnalysisRequest':
             self._ars = [self.context]
-        elif self.context.portal_type == 'AnalysisRequestsFolder' \
+        elif self.context.portal_type in ('AnalysisRequestsFolder', 'Client') \
                 and self.request.get('items', ''):
             uids = self.request.get('items').split(',')
             uc = getToolByName(self.context, 'uid_catalog')

--- a/bika/lims/browser/client/workflow.py
+++ b/bika/lims/browser/client/workflow.py
@@ -205,8 +205,7 @@ class ClientWorkflowAction(AnalysisRequestWorkflowAction):
                     its.append(uid)
             its = ",".join(its)
             q = "/publish?items=" + its
-            self.destination_url = self.request.get_header(
-                "referer", self.context.absolute_url()) + q
+            self.destination_url = self.context.absolute_url() + q
             self.request.response.redirect(self.destination_url)
 
         else:


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/424

## Current behavior before PR

Publication action from Client AR listing returned a "404 - not found"

## Desired behavior after PR is merged

Publication action from Client AR listing shows the publication preview

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
