### PR TITLE
Analyses are not sorted by sortkey in Analysis Request' manage analyses view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #433 Analyses not sorted by sortkey in Analysis Request' manage analyses view
 - #428 AR Publication from Client Listing does not work
 - #425 AR Listing View: Analysis profiles rendering error
 - #429 Fix worksheet switch to transposed layout raises an Error

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -31,7 +31,11 @@ class AnalysisRequestAnalysesView(BikaListingView):
         super(AnalysisRequestAnalysesView, self).__init__(context, request)
         self.catalog = "bika_setup_catalog"
         self.contentFilter = {'portal_type': 'AnalysisService',
+                              'sort_on': 'sortable_title',
+                              'sort_order': 'ascending',
                               'inactive_state': 'active', }
+        self.sort_on = 'sortable_title'
+        self.sort_order = 'ascending'
         self.context_actions = {}
         self.icon = self.portal_url + \
                     "/++resource++bika.lims.images/analysisrequest_big.png"
@@ -52,7 +56,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
             self.category_index = 'getCategoryTitle'
         self.columns = {
             'Title': {'title': _('Service'),
-                      'index': 'title',
+                      'index': 'sortable_title',
                       'sortable': False,
                       },
             'Unit': {
@@ -204,8 +208,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
         self.expand_all_categories = False
 
         wf = getToolByName(self.context, 'portal_workflow')
-        self.contentFilter['sort_on'] = 'title'
-        self.contentFilter['sort_order'] = 'ascending'
         items = BikaListingView.folderitems(self)
 
         parts = self.context.getSample().objectValues('SamplePartition')


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

In Analysis Request' manage analyses view, the list of Analysis Services doesn't follow the same sortkey logic criteria as in Analysis Services list, Manage Results, AR Add, etc.
Linked issue: https://github.com/senaite/bika.lims/issues/430

## Current behavior before PR

Services are listed in alphabetical order (AS category and service).

## Desired behavior after PR is merged

Services are listed following the sortkey logic consistently as in e.g. AR Add.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
