### PR TITLE
Only redirect to Analysis Request's Manage Results view if there aren't additional parts in the request

### DIFF
--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -4,9 +4,10 @@
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 from AccessControl import getSecurityManager
-from AccessControl.security import checkPermission
-from bika.lims import bikaMessageFactory as _, api
-from bika.lims.utils import t
+from DateTime import DateTime
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import bikaMessageFactory as _
 from bika.lims.browser import BrowserView
 from bika.lims.browser.analyses import AnalysesView
 from bika.lims.browser.analyses import QCAnalysesView
@@ -15,17 +16,13 @@ from bika.lims.browser.sample import SamplePartitionsView
 from bika.lims.config import POINTS_OF_CAPTURE
 from bika.lims.permissions import *
 from bika.lims.utils import isActive
+from bika.lims.utils import t, check_permission
 from bika.lims.utils import to_utf8
-from bika.lims.workflow import doActionFor, wasTransitionPerformed
-from DateTime import DateTime
 from bika.lims.workflow import doActionFor
+from bika.lims.workflow import wasTransitionPerformed
 from plone.app.layout.globals.interfaces import IViewView
-from Products.Archetypes import PloneMessageFactory as PMF
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
 
-import plone
 
 class AnalysisRequestViewView(BrowserView):
 
@@ -53,9 +50,9 @@ class AnalysisRequestViewView(BrowserView):
         # verified yet, redirect the user to manage_results view, but only if
         # the user has privileges to Edit(Field)Results, cause otherwise she/he
         # will receive an InsufficientPrivileges error!
-        mtool = api.get_tool('portal_membership')
-        if (mtool.checkPermission(EditResults, self.context) and
-            mtool.checkPermission(EditFieldResults, self.context) and
+        if (self.request.PATH_TRANSLATED.endswith(self.context.id) and
+            check_permission(EditResults, self.context) and
+            check_permission(EditFieldResults, self.context) and
             wasTransitionPerformed(self.context, 'receive') and
             not wasTransitionPerformed(self.context, 'verify')):
             # Redirect to manage results view


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

If an AR has been received, but not yet verified and the current has enough privileges, the system loads the "Manage results" view by default. With this Pull Request, this redirection only takes place if there is no other view explicitly set in the request. Thus, although user will be still redirected in "Manage results" when clicking in an Analysis Request link (e.g. in lists), the user will not be redirected when explicitly clicking to "View" or "Manage Analyses" or any other view.

## Current behavior before PR

User is always redirected to Manage Results view from Analysis Request if he/she has enough privileges and the AR has been received but not yet verified.

## Desired behavior after PR is merged

User is only redirected to Manage Results view from Analysis Request if he/she has enough privileges, the AR has been received but not yet verified AND there is no additional parts in the request url.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
