### PR TITLE
Fix for "Add" Actions in Instrument Views

### DIFF
--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -668,8 +668,18 @@ class InstrumentAutoImportLogsView(AutoImportLogsView):
                               'getInstrumentUID': self.context.UID(),
                               'sort_on': 'Created',
                               'sort_order': 'reverse'}
+
+        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentcertification_big.png"
         self.title = self.context.translate(
             _("Auto Import Logs of %s" % self.context.Title()))
+        self.context_actions = {}
+
+        self.show_table_only = False
+        self.show_sort_column = False
+        self.show_select_row = False
+        self.show_select_column = True
+        self.show_select_all_checkbox = False
+        self.pagesize = 25
 
 
 class InstrumentMultifileView(MultifileView):
@@ -680,6 +690,13 @@ class InstrumentMultifileView(MultifileView):
         self.show_workflow_action_buttons = False
         self.title = self.context.translate(_("Instrument Files"))
         self.description = "Different interesting documents and files to be attached to the instrument"
+
+        self.show_table_only = False
+        self.show_sort_column = False
+        self.show_select_row = False
+        self.show_select_column = True
+        self.show_select_all_checkbox = False
+        self.pagesize = 25
 
 
 class ajaxGetInstrumentMethods(BrowserView):

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -567,6 +567,12 @@ class InstrumentCertificationsView(BikaListingView):
         BikaListingView.__init__(self, context, request, **kwargs)
         self.form_id = "instrumentcertifications"
 
+        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentcertification_big.png"
+        self.title = self.context.translate(_("Calibration Certificates"))
+        self.context_actions = {_('Add'):
+                                {'url': 'createObject?type_name=InstrumentCertification',
+                                 'icon': '++resource++bika.lims.images/add.png'}}
+
         self.columns = {
             'Title': {'title': _('Cert. Num'), 'index': 'sortable_title'},
             'getAgency': {'title': _('Agency'), 'sortable': False},

--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
+#
 # This file is part of Bika LIMS
 #
-# Copyright 2011-2016 by it's authors.
+# Copyright 2011-2017 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 import json
@@ -36,58 +38,69 @@ class InstrumentMaintenanceView(BikaListingView):
         self.contentFilter = {
             'portal_type': 'InstrumentMaintenanceTask',
         }
+
+        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentmaintenance_big.png"
+        self.title = self.context.translate(_("Instrument Maintenance"))
         self.context_actions = {_('Add'):
                                 {'url': 'createObject?type_name=InstrumentMaintenanceTask',
                                  'icon': '++resource++bika.lims.images/add.png'}}
+
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
         self.show_select_all_checkbox = False
         self.pagesize = 40
         self.form_id = "instrumentmaintenance"
-        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentmaintenance_big.png"
-        self.title = self.context.translate(_("Instrument Maintenance"))
         self.description = ""
 
         self.columns = {
-            'getCurrentState' : {'title': ''},
+            'getCurrentState': {'title': ''},
             'Title': {'title': _('Task'),
                       'index': 'sortable_title'},
-            'getType' : {'title': _('Task type', 'Type'), 'sortable': True},
+            'getType': {'title': _('Task type', 'Type'), 'sortable': True},
             'getDownFrom': {'title': _('Down from'), 'sortable': True},
             'getDownTo': {'title': _('Down to'), 'sortable': True},
             'getMaintainer': {'title': _('Maintainer'), 'sortable': True},
         }
 
         self.review_states = [
-            {'id':'default',
-             'title': _('Open'),
-             'contentFilter': {'cancellation_state':'active'},
-             'columns': ['getCurrentState',
-                         'Title',
-                         'getType',
-                         'getDownFrom',
-                         'getDownTo',
-                         'getMaintainer']},
-            {'id':'cancelled',
-             'title': _('Cancelled'),
-             'contentFilter': {'cancellation_state': 'cancelled'},
-             'columns': ['getCurrentState',
-                         'Title',
-                         'getType',
-                         'getDownFrom',
-                         'getDownTo',
-                         'getMaintainer']},
-
-            {'id':'all',
-             'title': _('All'),
-             'contentFilter':{},
-             'columns': ['getCurrentState',
-                         'Title',
-                         'getType',
-                         'getDownFrom',
-                         'getDownTo',
-                         'getMaintainer']},
+            {
+                'id': 'default',
+                'title': _('Open'),
+                'contentFilter': {'cancellation_state': 'active'},
+                'columns': [
+                    'getCurrentState',
+                    'Title',
+                    'getType',
+                    'getDownFrom',
+                    'getDownTo',
+                    'getMaintainer',
+                ]
+            }, {
+                'id': 'cancelled',
+                'title': _('Cancelled'),
+                'contentFilter': {'cancellation_state': 'cancelled'},
+                'columns': [
+                    'getCurrentState',
+                    'Title',
+                    'getType',
+                    'getDownFrom',
+                    'getDownTo',
+                    'getMaintainer',
+                ]
+            }, {
+                'id': 'all',
+                'title': _('All'),
+                'contentFilter': {},
+                'columns': [
+                    'getCurrentState',
+                    'Title',
+                    'getType',
+                    'getDownFrom',
+                    'getDownTo',
+                    'getMaintainer'
+                ]
+            }
         ]
 
     def contentsMethod(self, *args, **kw):
@@ -99,20 +112,22 @@ class InstrumentMaintenanceView(BikaListingView):
         toshow = []
         for man in self.context.getMaintenanceTasks():
             toshow.append(man.UID())
-        for x in range (len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            if obj.UID() in toshow:
-                items[x]['getType'] = safe_unicode(_(obj.getType()[0])).encode('utf-8')
-                items[x]['getDownFrom'] = obj.getDownFrom() and self.ulocalized_time(obj.getDownFrom(), long_format=1) or ''
-                items[x]['getDownTo'] = obj.getDownTo() and self.ulocalized_time(obj.getDownTo(), long_format=1) or ''
-                items[x]['getMaintainer'] = safe_unicode(_(obj.getMaintainer())).encode('utf-8')
-                items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                     (items[x]['url'], safe_unicode(items[x]['Title']).encode('utf-8'))
 
-                status = obj.getCurrentState();
-                statustext = obj.getCurrentStateI18n();
-                statusimg = "";
+        for item in items:
+            if "obj" not in item:
+                continue
+            obj = item['obj']
+            if obj.UID() in toshow:
+                item['getType'] = safe_unicode(_(obj.getType()[0])).encode('utf-8')
+                item['getDownFrom'] = obj.getDownFrom() and self.ulocalized_time(obj.getDownFrom(), long_format=1) or ''
+                item['getDownTo'] = obj.getDownTo() and self.ulocalized_time(obj.getDownTo(), long_format=1) or ''
+                item['getMaintainer'] = safe_unicode(_(obj.getMaintainer())).encode('utf-8')
+                item['replace']['Title'] = "<a href='%s'>%s</a>" % \
+                    (item['url'], safe_unicode(item['Title']).encode('utf-8'))
+
+                status = obj.getCurrentState()
+                statustext = obj.getCurrentStateI18n()
+                statusimg = ""
                 if status == mstatus.CLOSED:
                     statusimg = "instrumentmaintenance_closed.png"
                 elif status == mstatus.CANCELLED:
@@ -124,11 +139,12 @@ class InstrumentMaintenanceView(BikaListingView):
                 elif status == mstatus.PENDING:
                     statusimg = "instrumentmaintenance_pending.png"
 
-                items[x]['replace']['getCurrentState'] = \
+                item['replace']['getCurrentState'] = \
                     "<img title='%s' src='%s/++resource++bika.lims.images/%s'/>" % \
                     (statustext, self.portal_url, statusimg)
-                outitems.append(items[x])
+                outitems.append(item)
         return outitems
+
 
 class InstrumentCalibrationsView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -139,17 +155,19 @@ class InstrumentCalibrationsView(BikaListingView):
         self.contentFilter = {
             'portal_type': 'InstrumentCalibration',
         }
+
+        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentcalibration_big.png"
+        self.title = self.context.translate(_("Instrument Calibrations"))
         self.context_actions = {_('Add'):
                                 {'url': 'createObject?type_name=InstrumentCalibration',
                                  'icon': '++resource++bika.lims.images/add.png'}}
+
         self.show_table_only = False
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 25
         self.form_id = "instrumentcalibrations"
-        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentcalibration_big.png"
-        self.title = self.context.translate(_("Instrument Calibrations"))
         self.description = ""
 
         self.columns = {
@@ -159,14 +177,19 @@ class InstrumentCalibrationsView(BikaListingView):
             'getDownTo': {'title': _('Down to')},
             'getCalibrator': {'title': _('Calibrator')},
         }
+
         self.review_states = [
-            {'id':'default',
-             'title':_('All'),
-             'contentFilter':{},
-             'columns': [ 'Title',
-                         'getDownFrom',
-                         'getDownTo',
-                         'getCalibrator']},
+            {
+                'id': 'default',
+                'title': _('All'),
+                'contentFilter': {},
+                'columns': [
+                    'Title',
+                    'getDownFrom',
+                    'getDownTo',
+                    'getCalibrator',
+                ]
+            }
         ]
 
     def contentsMethod(self, *args, **kw):
@@ -176,19 +199,24 @@ class InstrumentCalibrationsView(BikaListingView):
         items = BikaListingView.folderitems(self)
         outitems = []
         toshow = []
+
         for cal in self.context.getCalibrations():
             toshow.append(cal.UID())
-        for x in range (len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
+
+        for item in items:
+            if "obj" not in item:
+                continue
+            obj = item['obj']
             if obj.UID() in toshow:
-                items[x]['getDownFrom'] = obj.getDownFrom()
-                items[x]['getDownTo'] = obj.getDownTo()
-                items[x]['getCalibrator'] = obj.getCalibrator()
-                items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                     (items[x]['url'], items[x]['Title'])
-                outitems.append(items[x])
+                item['getDownFrom'] = obj.getDownFrom()
+                item['getDownTo'] = obj.getDownTo()
+                item['getCalibrator'] = obj.getCalibrator()
+                item['replace']['Title'] = "<a href='%s'>%s</a>" % \
+                    (item['url'], item['Title'])
+                outitems.append(item)
+
         return outitems
+
 
 class InstrumentValidationsView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -199,17 +227,19 @@ class InstrumentValidationsView(BikaListingView):
         self.contentFilter = {
             'portal_type': 'InstrumentValidation',
         }
+
+        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentvalidation_big.png"
+        self.title = self.context.translate(_("Instrument Validations"))
         self.context_actions = {_('Add'):
                                 {'url': 'createObject?type_name=InstrumentValidation',
                                  'icon': '++resource++bika.lims.images/add.png'}}
+
         self.show_table_only = False
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 25
         self.form_id = "instrumentvalidations"
-        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentvalidation_big.png"
-        self.title = self.context.translate(_("Instrument Validations"))
         self.description = ""
 
         self.columns = {
@@ -220,13 +250,17 @@ class InstrumentValidationsView(BikaListingView):
             'getValidator': {'title': _('Validator')},
         }
         self.review_states = [
-            {'id':'default',
-             'title':_('All'),
-             'contentFilter':{},
-             'columns': [ 'Title',
-                         'getDownFrom',
-                         'getDownTo',
-                         'getValidator']},
+            {
+                'id': 'default',
+                'title': _('All'),
+                'contentFilter': {},
+                'columns': [
+                    'Title',
+                    'getDownFrom',
+                    'getDownTo',
+                    'getValidator',
+                ]
+            }
         ]
 
     def contentsMethod(self, *args, **kw):
@@ -238,17 +272,19 @@ class InstrumentValidationsView(BikaListingView):
         toshow = []
         for val in self.context.getValidations():
             toshow.append(val.UID())
-        for x in range (len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
+        for item in items:
+            if "obj" not in item:
+                continue
+            obj = item['obj']
             if obj.UID() in toshow:
-                items[x]['getDownFrom'] = obj.getDownFrom()
-                items[x]['getDownTo'] = obj.getDownTo()
-                items[x]['getValidator'] = obj.getValidator()
-                items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                     (items[x]['url'], items[x]['Title'])
-                outitems.append(items[x])
+                item['getDownFrom'] = obj.getDownFrom()
+                item['getDownTo'] = obj.getDownTo()
+                item['getValidator'] = obj.getValidator()
+                item['replace']['Title'] = "<a href='%s'>%s</a>" % \
+                    (item['url'], item['Title'])
+                outitems.append(item)
         return outitems
+
 
 class InstrumentScheduleView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -258,11 +294,15 @@ class InstrumentScheduleView(BikaListingView):
         self.catalog = "portal_catalog"
         self.contentFilter = {
             'portal_type': 'InstrumentScheduledTask',
-            'getInstrumentUID()':context.UID(),
+            'getInstrumentUID()': context.UID(),
         }
+
+        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentschedule_big.png"
+        self.title = self.context.translate(_("Instrument Scheduled Tasks"))
         self.context_actions = {_('Add'):
                                 {'url': 'createObject?type_name=InstrumentScheduledTask',
                                  'icon': '++resource++bika.lims.images/add.png'}}
+
         self.show_table_only = False
         self.show_sort_column = False
         self.show_select_row = False
@@ -271,8 +311,6 @@ class InstrumentScheduleView(BikaListingView):
         self.pagesize = 25
 
         self.form_id = "instrumentschedule"
-        self.icon = self.portal_url + "/++resource++bika.lims.images/instrumentschedule_big.png"
-        self.title = self.context.translate(_("Instrument Scheduled Tasks"))
         self.description = ""
 
         self.columns = {
@@ -281,36 +319,46 @@ class InstrumentScheduleView(BikaListingView):
             'getType': {'title': _('Task type', 'Type')},
             'getCriteria': {'title': _('Criteria')},
             'creator': {'title': _('Created by')},
-            'created' : {'title': _('Created')},
+            'created': {'title': _('Created')},
         }
 
         self.review_states = [
-            {'id':'default',
-             'title': _('Active'),
-             'contentFilter': {'inactive_state': 'active'},
-             'transitions': [{'id':'deactivate'}, ],
-             'columns': [ 'Title',
-                         'getType',
-                         'getCriteria',
-                         'creator',
-                         'created']},
-            {'id':'inactive',
-             'title': _('Dormant'),
-             'contentFilter': {'inactive_state': 'inactive'},
-             'transitions': [{'id':'activate'}, ],
-             'columns': [ 'Title',
-                         'getType',
-                         'getCriteria',
-                         'creator',
-                         'created']},
-            {'id':'all',
-             'title': _('All'),
-             'contentFilter':{},
-             'columns': [ 'Title',
-                         'getType',
-                         'getCriteria',
-                         'creator',
-                         'created']},
+            {
+                'id': 'default',
+                'title': _('Active'),
+                'contentFilter': {'inactive_state': 'active'},
+                'transitions': [{'id': 'deactivate'}, ],
+                'columns': [
+                    'Title',
+                    'getType',
+                    'getCriteria',
+                    'creator',
+                    'created',
+                ]
+            }, {
+                'id': 'inactive',
+                'title': _('Dormant'),
+                'contentFilter': {'inactive_state': 'inactive'},
+                'transitions': [{'id': 'activate'}, ],
+                'columns': [
+                    'Title',
+                    'getType',
+                    'getCriteria',
+                    'creator',
+                    'created'
+                ]
+            }, {
+                'id': 'all',
+                'title': _('All'),
+                'contentFilter': {},
+                'columns': [
+                    'Title',
+                    'getType',
+                    'getCriteria',
+                    'creator',
+                    'created',
+                ]
+            }
         ]
 
     def contentsMethod(self, *args, **kw):
@@ -323,16 +371,17 @@ class InstrumentScheduleView(BikaListingView):
         for sch in self.context.getSchedule():
             toshow.append(sch.UID())
 
-        for x in range (len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
+        for item in items:
+            if "obj" not in item:
+                continue
+            obj = item['obj']
             if obj.UID() in toshow:
-                items[x]['created'] = self.ulocalized_time(obj.created())
-                items[x]['creator'] = obj.Creator()
-                items[x]['getType'] = safe_unicode(_(obj.getType()[0])).encode('utf-8')
-                items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                     (items[x]['url'], items[x]['Title'])
-                outitems.append(items[x])
+                item['created'] = self.ulocalized_time(obj.created())
+                item['creator'] = obj.Creator()
+                item['getType'] = safe_unicode(_(obj.getType()[0])).encode('utf-8')
+                item['replace']['Title'] = "<a href='%s'>%s</a>" % \
+                    (item['url'], item['Title'])
+                outitems.append(item)
         return outitems
 
 
@@ -353,8 +402,10 @@ class InstrumentReferenceAnalysesViewView(BrowserView):
 
     def __init__(self, context, request):
         super(InstrumentReferenceAnalysesViewView, self).__init__(context, request)
+
         self.icon = self.portal_url + "/++resource++bika.lims.images/referencesample_big.png"
         self.title = self.context.translate(_("Internal Calibration Tests"))
+
         self.description = ""
         self._analysesview = None
 
@@ -369,9 +420,8 @@ class InstrumentReferenceAnalysesViewView(BrowserView):
     def get_analyses_view(self):
         if not self._analysesview:
             # Creates the Analyses View if not exists yet
-            self._analysesview = InstrumentReferenceAnalysesView(self.context,
-                                    self.request,
-                                    show_categories=False)
+            self._analysesview = InstrumentReferenceAnalysesView(
+                self.context, self.request, show_categories=False)
             self._analysesview.allow_edit = False
             self._analysesview.show_select_column = False
             self._analysesview.show_workflow_action_buttons = False
@@ -393,12 +443,14 @@ class InstrumentReferenceAnalysesView(AnalysesView):
 
     def __init__(self, context, request, **kwargs):
         AnalysesView.__init__(self, context, request, **kwargs)
+
         self.columns['getReferenceAnalysesGroupID'] = {'title': _('QC Sample ID'),
                                                        'sortable': False}
+
         self.columns['Partition'] = {'title': _('Reference Sample'),
                                      'sortable': False}
         self.columns['Retractions'] = {'title': '',
-                                                  'sortable': False}
+                                       'sortable': False}
         self.review_states[0]['columns'] = ['Service',
                                             'getReferenceAnalysesGroupID',
                                             'Partition',
@@ -406,7 +458,6 @@ class InstrumentReferenceAnalysesView(AnalysesView):
                                             'Uncertainty',
                                             'CaptureDate',
                                             'Retractions']
-
 
         analyses = self.context.getReferenceAnalyses()
         asuids = [an.UID() for an in analyses]
@@ -417,8 +468,8 @@ class InstrumentReferenceAnalysesView(AnalysesView):
     def folderitems(self):
         items = AnalysesView.folderitems(self)
         items.sort(key=itemgetter('CaptureDate'), reverse=True)
-        for i in range(len(items)):
-            obj = items[i]['obj']
+        for item in items:
+            obj = item['obj']
             # TODO-performance: getting an object
             # Note here the object in items[i]['obj'] is a brain, cause the
             # base class (AnalysesView), calls folderitems(.., classic=False).
@@ -430,15 +481,15 @@ class InstrumentReferenceAnalysesView(AnalysesView):
                     imgtype = "<img title='%s' src='%s/++resource++bika.lims.images/control.png'/>&nbsp;" % (antype, self.context.absolute_url())
                 if obj.getReferenceType() == 'b':
                     imgtype = "<img title='%s' src='%s/++resource++bika.lims.images/blank.png'/>&nbsp;" % (antype, self.context.absolute_url())
-                items[i]['replace']['Partition'] = "<a href='%s'>%s</a>" % (obj.aq_parent.absolute_url(), obj.aq_parent.id)
+                item['replace']['Partition'] = "<a href='%s'>%s</a>" % (obj.aq_parent.absolute_url(), obj.aq_parent.id)
             elif obj.portal_type == 'DuplicateAnalysis':
                 antype = QCANALYSIS_TYPES.getValue('d')
                 imgtype = "<img title='%s' src='%s/++resource++bika.lims.images/duplicate.png'/>&nbsp;" % (antype, self.context.absolute_url())
-                items[i]['sortcode'] = '%s_%s' % (obj.getSample().id, obj.getKeyword())
+                item['sortcode'] = '%s_%s' % (obj.getSample().id, obj.getKeyword())
             else:
-                items[i]['sortcode'] = '%s_%s' % (obj.getSample().id, obj.getKeyword())
+                item['sortcode'] = '%s_%s' % (obj.getSample().id, obj.getKeyword())
 
-            items[i]['before']['Service'] = imgtype
+            item['before']['Service'] = imgtype
 
             # Get retractions field
             pdf = obj.getRetractedAnalysesPdfReport()
@@ -457,45 +508,46 @@ class InstrumentReferenceAnalysesView(AnalysesView):
                 # Show the record, but not the link
                 title = _('Retraction report unavailable')
                 anchor = title
-            items[i]['Retractions'] = title
-            items[i]['replace']['Retractions'] = anchor
-
+            item['Retractions'] = title
+            item['replace']['Retractions'] = anchor
 
             # Create json
-            qcid = obj.aq_parent.id;
-            serviceref = "%s (%s)" % (items[i]['Service'], items[i]['Keyword'])
-            trows = self.anjson.get(serviceref, {});
-            anrows = trows.get(qcid, []);
-            anid = '%s.%s' % (items[i]['getReferenceAnalysesGroupID'],
-                              items[i]['id'])
+            qcid = obj.aq_parent.getId()
+            serviceref = "%s (%s)" % (item['Service'], item['Keyword'])
+            trows = self.anjson.get(serviceref, {})
+            anrows = trows.get(qcid, [])
+            # anid = '%s.%s' % (item['getReferenceAnalysesGroupID'],
+            #                   item['id'])
 
             rr = obj.aq_parent.getResultsRangeDict()
             uid = obj.getServiceUID()
             if uid in rr:
-                specs = rr[uid];
+                specs = rr[uid]
                 try:
-                    smin  = float(specs.get('min', 0))
+                    smin = float(specs.get('min', 0))
                     smax = float(specs.get('max', 0))
-                    error  = float(specs.get('error', 0))
+                    error = float(specs.get('error', 0))
                     target = float(specs.get('result', 0))
-                    result = float(items[i]['Result'])
+                    result = float(item['Result'])
                     error_amount = ((target / 100) * error) if target > 0 else 0
-                    upper  = smax + error_amount
-                    lower   = smin - error_amount
+                    upper = smax + error_amount
+                    lower = smin - error_amount
 
-                    anrow = { 'date': items[i]['CaptureDate'],
-                              'min': smin,
-                              'max': smax,
-                              'target': target,
-                              'error': error,
-                              'erroramount': error_amount,
-                              'upper': upper,
-                              'lower': lower,
-                              'result': result,
-                              'unit': items[i]['Unit'],
-                              'id': items[i]['uid'] }
-                    anrows.append(anrow);
-                    trows[qcid] = anrows;
+                    anrow = {
+                        'date': item['CaptureDate'],
+                        'min': smin,
+                        'max': smax,
+                        'target': target,
+                        'error': error,
+                        'erroramount': error_amount,
+                        'upper': upper,
+                        'lower': lower,
+                        'result': result,
+                        'unit': item['Unit'],
+                        'id': item['uid']
+                    }
+                    anrows.append(anrow)
+                    trows[qcid] = anrows
                     self.anjson[serviceref] = trows
                 except:
                     pass
@@ -514,6 +566,7 @@ class InstrumentCertificationsView(BikaListingView):
     def __init__(self, context, request, **kwargs):
         BikaListingView.__init__(self, context, request, **kwargs)
         self.form_id = "instrumentcertifications"
+
         self.columns = {
             'Title': {'title': _('Cert. Num'), 'index': 'sortable_title'},
             'getAgency': {'title': _('Agency'), 'sortable': False},
@@ -522,17 +575,22 @@ class InstrumentCertificationsView(BikaListingView):
             'getValidTo': {'title': _('Valid to'), 'sortable': False},
             'getDocument': {'title': _('Document'), 'sortable': False},
         }
+
         self.review_states = [
-            {'id':'default',
-             'title':_('All'),
-             'contentFilter':{},
-             'columns': ['Title',
-                         'getAgency',
-                         'getDate',
-                         'getValidFrom',
-                         'getValidTo',
-                         'getDocument'],
-             'transitions': []},
+            {
+                'id': 'default',
+                'title': _('All'),
+                'contentFilter': {},
+                'columns': [
+                    'Title',
+                    'getAgency',
+                    'getDate',
+                    'getValidFrom',
+                    'getValidTo',
+                    'getDocument',
+                ],
+                'transitions': []
+            }
         ]
         self.allow_edit = False
         self.show_select_column = False
@@ -546,48 +604,48 @@ class InstrumentCertificationsView(BikaListingView):
         valid = [c.UID() for c in self.context.getValidCertifications()]
         latest = self.context.getLatestValidCertification()
         latest = latest.UID() if latest else ''
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-           # items[x]['getAgency'] = obj.getAgency()
-            items[x]['getDate'] = self.ulocalized_time(obj.getDate(), long_format=0)
-            items[x]['getValidFrom'] = self.ulocalized_time(obj.getValidFrom(), long_format=0)
-            items[x]['getValidTo'] = self.ulocalized_time(obj.getValidTo(), long_format=0)
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
-            if obj.getInternal() == True:
-                items[x]['replace']['getAgency'] = ""
-                items[x]['state_class'] = '%s %s' % (items[x]['state_class'], 'internalcertificate')
 
-            items[x]['getDocument'] = ""
-            items[x]['replace']['getDocument'] = ""
+        for item in items:
+            if "obj" not in item:
+                continue
+            obj = item['obj']
+            item['getDate'] = self.ulocalized_time(obj.getDate(), long_format=0)
+            item['getValidFrom'] = self.ulocalized_time(obj.getValidFrom(), long_format=0)
+            item['getValidTo'] = self.ulocalized_time(obj.getValidTo(), long_format=0)
+            item['replace']['Title'] = "<a href='%s'>%s</a>" % \
+                (item['url'], item['Title'])
+            if obj.getInternal() is True:
+                item['replace']['getAgency'] = ""
+                item['state_class'] = '%s %s' % (item['state_class'], 'internalcertificate')
+
+            item['getDocument'] = ""
+            item['replace']['getDocument'] = ""
             try:
                 doc = obj.getDocument()
                 if doc and doc.get_size() > 0:
                     anchor = "<a href='%s/at_download/Document'>%s</a>" % \
-                            (obj.absolute_url(), doc.filename)
-                    items[x]['getDocument'] = doc.filename
-                    items[x]['replace']['getDocument'] = anchor
+                        (obj.absolute_url(), doc.filename)
+                    item['getDocument'] = doc.filename
+                    item['replace']['getDocument'] = anchor
             except:
                 # POSKeyError: 'No blob file'
                 # Show the record, but not the link
-                title = _('Not available')
-                items[x]['getDocument'] = _('Not available')
-                items[x]['replace']['getDocument'] = _('Not available')
+                item['getDocument'] = _('Not available')
+                item['replace']['getDocument'] = _('Not available')
 
             uid = obj.UID()
             if uid in valid:
                 # Valid calibration.
-                items[x]['state_class'] = '%s %s' % (items[x]['state_class'], 'active')
+                item['state_class'] = '%s %s' % (item['state_class'], 'active')
             elif uid == latest:
                 # Latest valid certificate
                 img = "<img title='%s' src='%s/++resource++bika.lims.images/exclamation.png'/>&nbsp;" \
-                % (t(_('Out of date')), self.portal_url)
-                items[x]['replace']['getValidTo'] = '%s %s' % (items[x]['getValidTo'], img)
-                items[x]['state_class'] = '%s %s' % (items[x]['state_class'], 'inactive outofdate')
+                    % (t(_('Out of date')), self.portal_url)
+                item['replace']['getValidTo'] = '%s %s' % (item['getValidTo'], img)
+                item['state_class'] = '%s %s' % (item['state_class'], 'inactive outofdate')
             else:
                 # Old and further calibrations
-                items[x]['state_class'] = '%s %s' % (items[x]['state_class'], 'inactive')
+                item['state_class'] = '%s %s' % (item['state_class'], 'inactive')
 
         return items
 
@@ -604,8 +662,8 @@ class InstrumentAutoImportLogsView(AutoImportLogsView):
                               'getInstrumentUID': self.context.UID(),
                               'sort_on': 'Created',
                               'sort_order': 'reverse'}
-        self.title = self.context.translate(_("Auto Import Logs of %s" %
-                                              self.context.Title()))
+        self.title = self.context.translate(
+            _("Auto Import Logs of %s" % self.context.Title()))
 
 
 class InstrumentMultifileView(MultifileView):
@@ -660,11 +718,13 @@ class InstrumentQCFailuresViewlet(ViewletBase):
     def __init__(self, context, request, view, manager=None):
         super(InstrumentQCFailuresViewlet, self).__init__(context, request, view, manager=manager)
         self.nr_failed = 0
-        self.failed = {'out-of-date': [],
-                       'qc-fail': [],
-                       'next-test': [],
-                       'validation': [],
-                       'calibration': []}
+        self.failed = {
+            'out-of-date': [],
+            'qc-fail': [],
+            'next-test': [],
+            'validation': [],
+            'calibration': [],
+        }
 
     def get_failed_instruments(self):
         """ Find all active instruments who have failed QC tests
@@ -714,7 +774,6 @@ class InstrumentQCFailuresViewlet(ViewletBase):
                 self.failed['next-test'].append(instr)
 
     def render(self):
-
         mtool = getToolByName(self.context, 'portal_membership')
         member = mtool.getAuthenticatedMember()
         roles = member.getRoles()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/435

## Current behavior before PR

- Clicking on the Add Button of Instrument Certifications opens an arbitrary Add form of the system
- Auto Import View has an Add Button displayed, but shouldn't

## Desired behavior after PR is merged

Instrument Views behave properly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
