### PR TITLE
Disable automatic redirect to "Manage Results" in AR received state

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #438 Disable automatic redirect to "Manage Results" in AR received state
 - #433 Analyses not sorted by sortkey in Analysis Request' manage analyses view
 - #428 AR Publication from Client Listing does not work
 - #425 AR Listing View: Analysis profiles rendering error

--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -49,20 +49,6 @@ class AnalysisRequestViewView(BrowserView):
         if 'transition' in self.request.form:
             doActionFor(self.context, self.request.form['transition'])
 
-        # If the analysis request has been received and hasn't been yet
-        # verified yet, redirect the user to manage_results view, but only if
-        # the user has privileges to Edit(Field)Results, cause otherwise she/he
-        # will receive an InsufficientPrivileges error!
-        mtool = api.get_tool('portal_membership')
-        if (mtool.checkPermission(EditResults, self.context) and
-            mtool.checkPermission(EditFieldResults, self.context) and
-            wasTransitionPerformed(self.context, 'receive') and
-            not wasTransitionPerformed(self.context, 'verify')):
-            # Redirect to manage results view
-            manage_results_url = self.context.absolute_url() + '/manage_results'
-            self.request.response.redirect(manage_results_url)
-            return
-
         # Contacts get expanded for view
         contact = self.context.getContact()
         contacts = []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/437

## Current behavior before PR

If the AR was in received state, it was not possible anymore to access the AR View.
Therefore, it was not possible to change any base date of the AR

## Desired behavior after PR is merged

The user can change between the AR manage results view and base view freely.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
