### PR TITLE
Cannot verify calculated analyses if retracted dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Changelog
 
 **Fixed**
 
-- #437 Cannot verify calculated analyses when retracted dependencies
+- #439 Cannot verify calculated analyses when retracted dependencies
 - #436 Auto Import View has an Add Button displayed, but shouldn't
 - #436 Clicking on the Add Button of Instrument Certifications opens an arbitrary Add form
 - #433 Analyses not sorted by sortkey in Analysis Request' manage analyses view

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #433 Analyses not sorted by sortkey in Analysis Request' manage analyses view
 - #428 AR Publication from Client Listing does not work
 - #425 AR Listing View: Analysis profiles rendering error
 - #429 Fix worksheet switch to transposed layout raises an Error

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Changelog
 
 **Fixed**
 
+- #437 Cannot verify calculated analyses when retracted dependencies
 - #436 Auto Import View has an Add Button displayed, but shouldn't
 - #436 Clicking on the Add Button of Instrument Certifications opens an arbitrary Add form
 - #433 Analyses not sorted by sortkey in Analysis Request' manage analyses view

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -31,7 +31,11 @@ class AnalysisRequestAnalysesView(BikaListingView):
         super(AnalysisRequestAnalysesView, self).__init__(context, request)
         self.catalog = "bika_setup_catalog"
         self.contentFilter = {'portal_type': 'AnalysisService',
+                              'sort_on': 'sortable_title',
+                              'sort_order': 'ascending',
                               'inactive_state': 'active', }
+        self.sort_on = 'sortable_title'
+        self.sort_order = 'ascending'
         self.context_actions = {}
         self.icon = self.portal_url + \
                     "/++resource++bika.lims.images/analysisrequest_big.png"
@@ -52,7 +56,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
             self.category_index = 'getCategoryTitle'
         self.columns = {
             'Title': {'title': _('Service'),
-                      'index': 'title',
+                      'index': 'sortable_title',
                       'sortable': False,
                       },
             'Unit': {
@@ -204,8 +208,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
         self.expand_all_categories = False
 
         wf = getToolByName(self.context, 'portal_workflow')
-        self.contentFilter['sort_on'] = 'title'
-        self.contentFilter['sort_order'] = 'ascending'
         items = BikaListingView.folderitems(self)
 
         parts = self.context.getSample().objectValues('SamplePartition')

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -411,8 +411,12 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         raise NotImplementedError("getDependents is not implemented.")
 
     @security.public
-    def getDependencies(self):
-        """Return a list of analyses who we depend on to calculate our result.
+    def getDependencies(self, retracted=False):
+        """Return a list of siblings who we depend on to calculate our result.
+        :param retracted: If false retracted/rejected analyses are dismissed
+        :type retracted: bool
+        :return: Analyses the current analysis depends on
+        :rtype: list of IAnalysis
         """
         raise NotImplementedError("getDependencies is not implemented.")
 

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -43,9 +43,6 @@ class Analysis(AbstractRoutineAnalysis):
         :return: list of siblings for this analysis
         :rtype: list of IAnalysis
         """
-        """Returns the list of analyses of the Analysis Request to which this
-        analysis belongs to, but with the current analysis excluded
-        """
         request = self.getRequest()
         if not request:
             return []
@@ -55,10 +52,15 @@ class Analysis(AbstractRoutineAnalysis):
         ans = request.getAnalyses(full_objects=True)
         for sibling in ans:
             if sibling.UID() == self.UID():
+                # Exclude me from the list
                 continue
+
             if retracted is False and in_state(sibling, retracted_states):
+                # Exclude retracted analyses
                 continue
+
             siblings.append(sibling)
+
         return siblings
 
 

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -56,7 +56,7 @@ class Analysis(AbstractRoutineAnalysis):
         for sibling in ans:
             if sibling.UID() == self.UID():
                 continue
-            if retracted == False and in_state(sibling, retracted_states):
+            if retracted is False and in_state(sibling, retracted_states):
                 continue
             siblings.append(sibling)
         return siblings

--- a/bika/lims/content/duplicateanalysis.py
+++ b/bika/lims/content/duplicateanalysis.py
@@ -104,7 +104,7 @@ class DuplicateAnalysis(AbstractRoutineAnalysis):
                 if analysis.getRequestUID() != requestuid:
                     continue
 
-                if retracted == False and in_state(analysis, retracted_states):
+                if retracted is False and in_state(analysis, retracted_states):
                     continue
 
                 siblings.append(analysis)

--- a/bika/lims/content/duplicateanalysis.py
+++ b/bika/lims/content/duplicateanalysis.py
@@ -82,10 +82,6 @@ class DuplicateAnalysis(AbstractRoutineAnalysis):
         :return: list of siblings for this analysis
         :rtype: list of IAnalysis
         """
-        """Returns the list of duplicate analyses that share the same Request
-        and are included in the same Worksheet as the current. The current
-        duplicate is excluded from the list
-        """
         worksheet = self.getWorksheet()
         requestuid = self.getRequestUID()
         if not requestuid or not worksheet:
@@ -98,16 +94,23 @@ class DuplicateAnalysis(AbstractRoutineAnalysis):
             if analysis.UID() == self.UID():
                 # Exclude me from the list
                 continue
-            if IRequestAnalysis.providedBy(analysis):
-                # We exclude here all analyses that do not have an analysis
-                # request associated (e.g. IReferenceAnalysis)
-                if analysis.getRequestUID() != requestuid:
-                    continue
 
-                if retracted is False and in_state(analysis, retracted_states):
-                    continue
+            if IRequestAnalysis.providedBy(analysis) is False:
+                # Exclude analyses that do not have an analysis request
+                # associated
+                continue
 
-                siblings.append(analysis)
+            if analysis.getRequestUID() != requestuid:
+                # Exclude those analyses that does not belong to the same
+                # analysis request I belong to
+                continue
+
+            if retracted is False and in_state(analysis, retracted_states):
+                # Exclude retracted analyses
+                continue
+
+            siblings.append(analysis)
+
         return siblings
 
     @security.public

--- a/bika/lims/content/referenceanalysis.py
+++ b/bika/lims/content/referenceanalysis.py
@@ -135,7 +135,7 @@ class ReferenceAnalysis(AbstractAnalysis):
             return ins.absolute_url_path()
         return ''
 
-    def getDependencies(self):
+    def getDependencies(self, retracted=False):
         """It doesn't make sense for a ReferenceAnalysis to use
         dependencies, since them are only used in calculations for
         routine analyses

--- a/bika/lims/workflow/__init__.py
+++ b/bika/lims/workflow/__init__.py
@@ -376,6 +376,13 @@ def getCurrentState(obj, stateflowid='review_state'):
     wf = getToolByName(obj, 'portal_workflow')
     return wf.getInfoFor(obj, stateflowid, '')
 
+def in_state(obj, states, stateflowid='review_state'):
+    """ Returns if the object passed matches with the states passed in
+    """
+    if not states:
+        return False
+    obj_state = getCurrentState(obj, stateflowid=stateflowid)
+    return obj_state in states
 
 def getTransitionActor(obj, action_id):
     """Returns the actor that performed a given transition. If transition has

--- a/bika/lims/workflow/analysis/__init__.py
+++ b/bika/lims/workflow/analysis/__init__.py
@@ -1,0 +1,2 @@
+STATE_REJECTED = 'rejected'
+STATE_RETRACTED = 'retracted'


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

To determine if a given analysis can be transitioned from `to_be_verified` to `verified` state, the system checks if this analysis has dependencies (analyses the analysis depends on to calculate its result). If these dependencies, in turn can be transitioned from `to_be_verified` to `verified` or the transition `verify` for these dependencies has already been performed, then the system returns `True`, so the target analysis can be transitioned to `verified` state. Otherwise, the system, returns False (the target analysis cannot be transitioned to `verified` state.

All these checks live in `bika.lims.workflow.analysis.events` and specially in `bika.lims.workflow.analysis.guards`, cause the guard is always checked (as per DC workflow default behavior) when using DC's workflow tool to obtain the available transitions for a given state and obect.

When returning the dependencies of a given analysis, the system was including analyses that were retracted (or rejected), and because from a retracted/rejected status there is no possibility to reach neither `to_be_verified` or `verified` state, the system was not allowing the `verify` transition to analyses that had dependencies with `retracted` or `rejected` states. 

With this PR, the system returns the dependencies excluding retracted/rejected analyses by default. The same criteria has been applied to dependents (analyses that depends on the target analysis). Because both `getDependents` and `getDependencies` rely on `getSiblings` the logic for this fix has been delegated to `getSiblings` function. The code has been inspected carefully from a functional point of view if there was any place that retracted dependents/depencies were required.

## Current behavior before PR

The user cannot verify analyses with retracted dependencies

## Desired behavior after PR is merged

The user can verify analyses with retracted dependencies

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
