### PR TITLE
pinned five.pt

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -136,3 +136,4 @@ scripts = ipython=ipzope
 setuptools =
 zc.buildout =
 CairoSVG = 1.0.20
+five.pt = 2.2.4

--- a/travis.cfg
+++ b/travis.cfg
@@ -25,3 +25,4 @@ zc.recipe.egg = 1.3.2
 zope.pagetemplate = 3.6.3
 plone.recipe.codeanalysis = 1.0b5
 mock = 1.0.1
+five.pt = 2.2.4


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Pin `five.pt` to avoid pulling Zope >= 4

## Current behavior before PR

Travis fails

## Desired behavior after PR is merged

Travis works

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
