### PR TITLE
Traceback in Instruments list after adding a calibration certificate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 
 **Fixed**
 
+- #451 Traceback in Instruments list after adding a calibration certificate
 - #445 Fix AR Add Form: No sample points are found if a sample type was set
 
 **Security**

--- a/bika/lims/content/instrument.py
+++ b/bika/lims/content/instrument.py
@@ -619,7 +619,7 @@ class Instrument(ATFolder):
         cert = self.getLatestValidCertification()
         today = date.today()
         if cert and cert.getValidTo():
-            validto = cert.getValidTo().asdatetime().date();
+            validto = cert.getValidTo().asdatetime().date()
             if validto > today:
                 return False
         return True
@@ -654,13 +654,38 @@ class Instrument(ATFolder):
         return date
 
     def getWeeksToExpire(self):
-        """ Returns the amount of weeks untils it's certification expire
+        """
+        Returns the amount of weeks and days until the latest valid
+        certification for this instrument gets expired.
         """
         cert = self.getLatestValidCertification()
         if cert == None:
             return ''
-        date = cert.getValidTo().asdatetime().date();
-        return date - date.today()
+
+        date_to = cert.getValidTo()
+        if not date_to:
+            return 0, 0
+
+        expired = False
+        date_from = date.today()
+        date_to = date_to.asdatetime().date()
+        if date_from > date_to:
+            # Out of date, already expired
+            date_from = date_to
+            date_to = date.today()
+            expired = True
+
+        # Get the number of total days between the two dates
+        total_days = (date_to - date_from).days
+        days = total_days % 7
+        weeks = total_days / 7
+        if days > 0:
+            weeks = (total_days - days) / 7
+
+        days = -days if expired else days
+        weeks = -weeks if expired else weeks
+        return weeks, days
+
 
     def getLatestValidCertification(self):
         """ Returns the latest valid certification. If no latest valid


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Traceback is rised in Instruments list after adding a calibration certificate to one of them
Linked issue: https://github.com/senaite/bika.lims/issues/442

## Current behavior before PR

The following traceback is rised in instruments list after adding a calibration certificate to one of them:

```
Module ZPublisher.Publish, line 138, in publish
Module ZPublisher.mapply, line 77, in mapply
Module ZPublisher.Publish, line 48, in call_object
Module bika.lims.browser.bika_listing, line 936, in call
Module Products.Five.browser.pagetemplatefile, line 125, in call
Module Products.Five.browser.pagetemplatefile, line 59, in call
Module zope.pagetemplate.pagetemplate, line 132, in pt_render
Module five.pt.engine, line 98, in call
Module z3c.pt.pagetemplate, line 163, in render
Module chameleon.zpt.template, line 276, in render
Module chameleon.template, line 191, in render
Module chameleon.template, line 171, in render
Module a4d4e8c1e59c4a4e78270b349f009dc7.py, line 519, in render
Module bab1671251b6685272775265b52480e7.py, line 1420, in render_master
Module bab1671251b6685272775265b52480e7.py, line 578, in render_content
Module a4d4e8c1e59c4a4e78270b349f009dc7.py, line 417, in __fill_content_core
Module five.pt.expressions, line 161, in call
Module bika.lims.browser.bika_listing, line 1376, in contents_table
Module bika.lims.browser.bika_listing, line 1536, in init
Module bika.lims.controlpanel.bika_instruments, line 121, in folderitems
TypeError: 'datetime.timedelta' object is not iterable
```

## Desired behavior after PR is merged

The list of instruments is displayed without any error

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
