### PR TITLE
Traceback error when deleting attachment from Analysis Request

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 
 **Fixed**
 
+- #452 Traceback error when deleting attachment from Analysis Request
 - #450 Traceback after clicking "Manage Results" in a WS w/o Analyses assigned
 - #445 Fix AR Add Form: No sample points are found if a sample type was set
 

--- a/bika/lims/browser/fields/uidreferencefield.py
+++ b/bika/lims/browser/fields/uidreferencefield.py
@@ -278,13 +278,16 @@ def get_backreferences(context, relationship=None, as_brains=None):
     instance = context.aq_base
     raw_backrefs = get_storage(instance)
 
-    if relationship:
-        backrefs = list(raw_backrefs.get(relationship, []))
-        if as_brains:
-            cat = _get_catalog_for_uid(backrefs[0])
-            backrefs = cat(UID=backrefs)
-    else:
+    if not relationship:
         assert not as_brains, "You cannot use as_brains with no relationship"
-        backrefs = raw_backrefs
+        return raw_backrefs
 
-    return backrefs
+    backrefs = list(raw_backrefs.get(relationship, []))
+    if not backrefs:
+        return []
+
+    if not as_brains:
+        return backrefs
+
+    cat = _get_catalog_for_uid(backrefs[0])
+    return cat(UID=backrefs)

--- a/bika/lims/content/attachment.py
+++ b/bika/lims/content/attachment.py
@@ -140,14 +140,13 @@ class Attachment(BaseFolder):
         """
         request_id = self.getRequestID()
         if not request_id:
-            return None
+            return ''
 
         analysis = self.getAnalysis()
         if not analysis:
             return request_id
 
         return '%s - %s' % (request_id, analysis.Title())
-
 
     def getRequest(self):
         """Return the AR to which this is linked there is a short time between
@@ -158,7 +157,13 @@ class Attachment(BaseFolder):
         tool = getToolByName(self, REFERENCE_CATALOG)
         uids = [uid for uid in
                 tool.getBackReferences(self, 'AnalysisRequestAttachment')]
-        if len(uids) == 1:
+
+        if len(uids) > 1:
+            logger.warn("Attachment assigned to more than one Analysis Request."
+                        "This should never happen!. The first Analysis Request"
+                        "will be returned.")
+
+        if len(uids) > 0:
             reference = uids[0]
             ar = tool.lookupObject(reference.sourceUID)
             return ar
@@ -195,20 +200,6 @@ class Attachment(BaseFolder):
 
         analysis = api.get_object(analysis[0])
         return analysis
-
-    def getParentState(self):
-        """Return the review state of the object - analysis or AR to which
-        this is linked
-        """
-        analysis = self.getAnalysis()
-        if analysis:
-            return getCurrentState(analysis)
-
-        analysis_request = self.getRequest()
-        if analysis_request:
-            return getCurrentState(analysis_request)
-
-        return ''
 
     security.declarePublic('current_date')
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

The user cannot remove an attachment from an Analysis Request, but assigned to a particular Analysis. The reason is that while the relationship between AnalysisRequest and Attachment still uses `ReferenceField`, the relationship between Analysis and Attachment is based on an `UIDReferenceField`. The code from `bika.lims.content.attachment` that retrieves either the Analysis Request or the Analysis was always using the reference catalog. With this Pull Request, the retrieval of the Analysis the current Attachment is related to is done by using `get_backreferences` function from `bika.lims.browser.uidreferencefield`.

Linked issue: [Traceback error when deleting attachment from AR #441](https://github.com/senaite/bika.lims/issues/441)

## Current behavior before PR

A traceback is rised when trying to remove an Attachment from an Analysis Request that was explicitly assigned to an Analysis:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.attachment, line 81, in __call__
  Module bika.lims.browser.attachment, line 100, in action_update
  Module bika.lims.browser.attachment, line 189, in delete_attachment
AttributeError: 'NoneType' object has no attribute 'getAttachment'
```
## Desired behavior after PR is merged

The user can remove an Attachment from an Analysis Request that was explicitly assigned to an Analysis.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
