### PR TITLE
Issue-383: Click on some analyses pops up a new page instead of object log

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 
 **Fixed**
 
+- #454 Click on some analyses pops up a new page instead of object log
 - #450 Traceback after clicking "Manage Results" in a WS w/o Analyses assigned
 - #445 Fix AR Add Form: No sample points are found if a sample type was set
 

--- a/bika/lims/browser/analysisservice.py
+++ b/bika/lims/browser/analysisservice.py
@@ -3,27 +3,31 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from bika.lims.browser import BrowserView
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from bika.lims import bikaMessageFactory as _
-from bika.lims.jsonapi import load_field_values, get_include_fields
-from bika.lims.utils import t
-from bika.lims.config import POINTS_OF_CAPTURE
-from bika.lims.browser.log import LogView
-from bika.lims.content.analysisservice import getContainers
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.interfaces import IAnalysisService
-from bika.lims.interfaces import IJSONReadExtender
+import json
+
 from Products.CMFCore.utils import getToolByName
-from magnitude import mg, MagnitudeError
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
 from zope.component import adapts
 from zope.interface import implements
-import json, plone
+
+import plone
 import plone.protect
-import re
+
+from magnitude import mg
+
+from bika.lims import bikaMessageFactory as _
+from bika.lims.browser import BrowserView
+from bika.lims.browser.log import LogView
+from bika.lims.config import POINTS_OF_CAPTURE
+from bika.lims.content.analysisservice import getContainers
+from bika.lims.interfaces import IAnalysisService
+from bika.lims.interfaces import IJSONReadExtender
+from bika.lims.jsonapi import load_field_values, get_include_fields
 from bika.lims.utils import to_unicode
 
-### AJAX methods for AnalysisService context
+# AJAX methods for AnalysisService context
+
 
 class ajaxGetContainers(BrowserView):
     """ajax Preservation/Container widget filter
@@ -35,27 +39,27 @@ class ajaxGetContainers(BrowserView):
     """
     def __call__(self):
         plone.protect.CheckAuthenticator(self.request)
-        uc = getToolByName(self, 'uid_catalog')
 
         allow_blank = self.request.get('allow_blank', False) == 'true'
         show_container_types = json.loads(self.request.get('show_container_types', 'true'))
         show_containers = json.loads(self.request.get('show_containers', 'true'))
         minvol = self.request.get("minvol", "0")
         try:
-            minvol =  minvol.split()
+            minvol = minvol.split()
             minvol = mg(float(minvol[0]), " ".join(minvol[1:]))
         except:
             minvol = mg(0)
 
         containers = getContainers(
             self.context,
-            minvol = minvol,
-            allow_blank = allow_blank,
+            minvol=minvol,
+            allow_blank=allow_blank,
             show_containers=show_containers,
             show_container_types=show_container_types,
         )
 
         return json.dumps(containers)
+
 
 class ajaxServicePopup(BrowserView):
 
@@ -96,22 +100,20 @@ class ajaxServicePopup(BrowserView):
         self.partsetup = self.service.getPartitionSetup()
 
         # convert uids to comma-separated list of display titles
-        for i,ps in enumerate(self.partsetup):
+        for i, ps in enumerate(self.partsetup):
+            self.partsetup[i]['separate'] = 'separate' in ps and _('Yes') or _('No')
 
-            self.partsetup[i]['separate'] = \
-                ps.has_key('separate') and _('Yes') or _('No')
-
-            if type(ps['sampletype']) == str:
-                ps['sampletype'] = [ps['sampletype'],]
+            if isinstance(ps['sampletype'], basestring):
+                ps['sampletype'] = [ps['sampletype'], ]
             sampletypes = []
             for st in ps['sampletype']:
                 res = bsc(UID=st)
                 sampletypes.append(res and res[0].Title or st)
             self.partsetup[i]['sampletype'] = ", ".join(sampletypes)
 
-            if ps.has_key('container'):
-                if type(ps['container']) == str:
-                    self.partsetup[i]['container'] = [ps['container'],]
+            if 'container' in ps:
+                if isinstance(ps['container'], basestring):
+                    self.partsetup[i]['container'] = [ps['container'], ]
                 try:
                     containers = [bsc(UID=c)[0].Title for c in ps['container']]
                 except IndexError:
@@ -120,9 +122,9 @@ class ajaxServicePopup(BrowserView):
             else:
                 self.partsetup[i]['container'] = ''
 
-            if ps.has_key('preservation'):
-                if type(ps['preservation']) == str:
-                    ps['preservation'] = [ps['preservation'],]
+            if 'preservation' in ps:
+                if isinstance(ps['preservation'], basestring):
+                    ps['preservation'] = [ps['preservation'], ]
                 try:
                     preservations = [bsc(UID=c)[0].Title for c in ps['preservation']]
                 except IndexError:

--- a/bika/lims/browser/templates/analysisservice_popup.pt
+++ b/bika/lims/browser/templates/analysisservice_popup.pt
@@ -1,305 +1,273 @@
-<html
-    i18n:domain="bika"
-	tal:define="portal_state context/@@plone_portal_state;
-				portal_url portal_state/portal_url;
-				locale portal_state/locale;
-				currency python:context.bika_setup.getCurrency();
-		        ShowPrices python:context.bika_setup.getShowPrices();">
-<head>
+<html i18n:domain="bika"
+      tal:define="portal_state context/@@plone_portal_state;
+                  portal_url portal_state/portal_url;
+                  locale portal_state/locale;
+                  currency python:context.bika_setup.getCurrency();
+                  ShowPrices python:context.bika_setup.getShowPrices();">
+  <head>
+    <style type="text/css">
+     .service_popup {
+         font-size:70%;
+         color:#222;
+     }
+     .service_popuph5,
+     .service_popupp {
+         margin-bottom:5px; }
+     .service_popup .documentDescription {
+         margin-bottom:5px; }
+     .service_popup #serviceDescription { }
+     .service_popup #methodDescription { }
+     .service_popup #file_list { margin-bottom:1em; }
+     .service_popup #file_list a { margin-left:1.5em; }
+     .service_popup #deps_list { margin-bottom:1em;padding-left:1.5em; }
+     .service_popup #parts_list { margin-bottom:1em;padding-left:1.5em; }
+     .service_popup th {
+         background-color:#eee;
+         border-bottom:1px solid #ccc;
+         padding:2px 5px;
+         font-weight:bold;
+     }
+     .service_popup td {
+         padding:1px 5px;
+         border-bottom:1px solid #eee;
+     }
+     .service_popup #analysis_log { margin-bottom:1em;padding-left:1.5em; }
+    </style>
 
-	<style>
-		.service_popup {
-		    font-size:70%;
-			color:#222;
-		}
-		.service_popuph5,
-		.service_popupp {
-			margin-bottom:5px; }
-		.service_popup .documentDescription {
-			margin-bottom:5px; }
-		.service_popup #serviceDescription { }
-		.service_popup #methodDescription { }
-		.service_popup #file_list { margin-bottom:1em; }
-		.service_popup #file_list a { margin-left:1.5em; }
-		.service_popup #deps_list { margin-bottom:1em;padding-left:1.5em; }
-		.service_popup #parts_list { margin-bottom:1em;padding-left:1.5em; }
-		.service_popup th {
-		    background-color:#eee;
-		    border-bottom:1px solid #ccc;
-			padding:2px 5px;
-			font-weight:bold;
-		}
-		.service_popup td {
-		    padding:1px 5px;
-			border-bottom:1px solid #eee;
-		}
-		.service_popup #analysis_log { margin-bottom:1em;padding-left:1.5em; }
-	</style>
+  </head>
 
-</head>
+  <body tal:define="currencies python:modules['zope.i18n.locales'].locales.getLocale('en').numbers.currencies;">
 
-<body
-  tal:define="currencies python:modules['zope.i18n.locales'].locales.getLocale('en').numbers.currencies;">
+    <div class="service_popup">
+      <div id="serviceDescription"
+           class="documentDescription"
+           tal:define="description view/service/Description"
+           tal:condition="description"
+           tal:content="description"/>
 
-<div class="service_popup">
+      <h5 tal:condition="python:context.bika_setup.laboratory.LaboratoryAccredited
+                         and view.service.getAccredited()">
+        <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/accredited.png"/>
+        <span i18n:translate="">
+          Service is included in the
+          <span i18n:name="accreditation_body_abbrev">
+            schedule of Accreditation for this Laboratory
+          </span>
+        </span>
+      </h5>
 
-    <div
-		id="serviceDescription"
-		class="documentDescription"
-		tal:define="description view/service/Description"
-		tal:condition="description"
-		tal:content="description"/>
+      <h5 tal:condition="view/service/getReportDryMatter">
+        <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/dry.png"/>
+        <span i18n:translate="">
+          Can be reported as dry matter
+        </span>
+      </h5>
 
-	<h5
-		tal:condition="python:context.bika_setup.laboratory.LaboratoryAccredited
-		                      and view.service.getAccredited()">
-		<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/accredited.png"/>
-		<span i18n:translate="">
-			Service is included in the
-			<span i18n:name="accreditation_body_abbrev">
-			schedule of Accreditation for this Laboratory
-		</span>
-		</span>
-	</h5>
+      <tal:method define="method view/service/getMethod"
+                  condition="method">
+        <h5>
+          <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/method.png"/>
+          <span i18n:translate="">
+            Method:
+            <span i18n:name="method_name">
+              <a tal:attributes="href python:method.absolute_url()"
+                 target="_blank"
+                 tal:content="method/Title"/>
+            </span>
+          </span>
+        </h5>
 
-	<h5
-		tal:condition="view/service/getReportDryMatter">
-		<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/dry.png"/>
-		<span i18n:translate="">
-			Can be reported as dry matter
-		</span>
-	</h5>
-
-    <tal:method
-		define="method view/service/getMethod"
-		condition="method">
-
-		<h5>
-			<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/method.png"/>
-			<span i18n:translate="">
-				Method:
-				<span i18n:name="method_name">
-					<a
-						tal:attributes="href python:method.absolute_url()"
-						target="_blank"
-						tal:content="method/Title"/>
-				</span>
-			</span>
-		</h5>
-
-		<div
-			id="methodDescription"
-			class="documentDescription"
-			tal:define="description method/Description"
-			tal:condition="description"
-			tal:content="description"/>
+        <div id="methodDescription"
+             class="documentDescription"
+             tal:define="description method/Description"
+             tal:condition="description"
+             tal:content="description"/>
 
         <div id="file_list"
-			tal:condition="filename"
-			tal:define="
-				file method/MethodDocument;
-				filename python:getattr(file, 'filename', '');
-                filesize python:file.getObjSize();
-                icon file/icon | nothing;">
-			<h5>
-				<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/attachment.png"/>
-				<span i18n:translate="">
-					Method Document
-				</span>
-			</h5>
-			<a
-				title="Click to download"
-				i18n:attributes="title"
-				tal:condition="filename"
-                tal:attributes="href string:${method/absolute_url}/at_download/MethodDocument">
-				<img tal:condition="icon" src=""
-					tal:attributes="src string:portal_url/$icon"/>
-				<tal:filename replace="filename"/>
-				(<span class="discreet" tal:content="filesize">0Kb</span>)
-			</a>
-		</div>
+             tal:condition="filename"
+             tal:define="file method/MethodDocument;
+                         filename python:getattr(file, 'filename', '');
+                         filesize python:file.getObjSize();
+                         icon file/icon | nothing;">
+          <h5>
+            <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/attachment.png"/>
+            <span i18n:translate="">
+              Method Document
+            </span>
+          </h5>
+          <a title="Click to download"
+             i18n:attributes="title"
+             tal:condition="filename"
+             tal:attributes="href string:${method/absolute_url}/at_download/MethodDocument">
+            <img src=""
+                 tal:condition="icon"
+                 tal:attributes="src string:portal_url/$icon"/>
+            <tal:filename replace="filename"/>
+            (<span class="discreet" tal:content="filesize">0Kb</span>)
+          </a>
+        </div>
+      </tal:method>
 
-	</tal:method>
+      <tal:nomethod condition="not:view/service/getMethod">
+        <h5>
+          <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/method.png"/>
+          <span i18n:translate="">
+            Method: None
+          </span>
+        </h5>
+      </tal:nomethod>
 
-    <tal:nomethod
-		condition="not:view/service/getMethod">
-		<h5>
-			<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/method.png"/>
-			<span i18n:translate="">
-				Method: None
-			</span>
-		</h5>
-	</tal:nomethod>
+      <tal:calc define="calc nocall:view/calc;
+                        deps python:calc and calc.getDependentServices() or []"
+                condition="calc">
 
-    <tal:calc
-		define="calc nocall:view/calc;
-				deps python:calc and calc.getDependentServices() or []"
-		condition="calc">
-
-		<h5>
-			<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/calculation.png"/>
-			<span i18n:translate="">
-				Calculation:
-				<span i18n:name="calc_name">
-					<a
-						tal:attributes="href python:calc.absolute_url()"
-						target="_blank"
-						tal:content="calc/Title"/>
-				</span>
-			</span>
-		</h5>
+        <h5>
+          <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/calculation.png"/>
+          <span i18n:translate="">
+            Calculation:
+            <span i18n:name="calc_name">
+              <a
+                tal:attributes="href python:calc.absolute_url()"
+                                target="_blank"
+                                tal:content="calc/Title"/>
+            </span>
+          </span>
+        </h5>
 
         <div id="deps_list" tal:condition="deps">
-			<h5>
-				<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/dependencies.png"/>
-				<span i18n:translate="">
-					Dependent Analyses
-				</span>
-			</h5>
+          <h5>
+            <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/dependencies.png"/>
+            <span i18n:translate="">
+              Dependent Analyses
+            </span>
+          </h5>
 
-			<table>
-				<tr>
-					<th i18n:translate="">Service</th>
-					<th i18n:translate="">Category</th>
-					<th i18n:translate="">Keyword</th>
-					<th i18n:translate="">Method</th>
-					<th i18n:translate="" tal:condition="ShowPrices">Price</th>
-				</tr>
-				<tr tal:repeat="dep deps">
-					<td>
-						<a
-							target="_blank"
-							tal:attributes="href python:dep.absolute_url()"
-							tal:content="dep/Title"/>
-					</td>
-					<td tal:content="python:dep.getCategoryTitle()"/>
-					<td tal:content="python:dep.getKeyword()"/>
-					<td>
-						<a
-							tal:define="m python:dep.getMethod()"
-							tal:condition="m"
-							tal:attributes="href python:m.absolute_url()"
-							tal:content="m/Title"/>
-					</td>
-					<td tal:condition="ShowPrices">
-						<span tal:replace="python:currencies[currency].symbol"/>
-						<span tal:replace="python:'%.02f'%dep.getTotalPrice()"/>
-					</td>
-				</tr>
-			</table>
+          <table>
+            <tr>
+              <th i18n:translate="">Service</th>
+              <th i18n:translate="">Category</th>
+              <th i18n:translate="">Keyword</th>
+              <th i18n:translate="">Method</th>
+              <th i18n:translate="" tal:condition="ShowPrices">Price</th>
+            </tr>
+            <tr tal:repeat="dep deps">
+              <td>
+                <a target="_blank"
+                   tal:attributes="href python:dep.absolute_url()"
+                   tal:content="dep/Title"/>
+              </td>
+              <td tal:content="python:dep.getCategoryTitle()"/>
+              <td tal:content="python:dep.getKeyword()"/>
+              <td>
+                <a tal:define="m python:dep.getMethod()"
+                   tal:condition="m"
+                   tal:attributes="href python:m.absolute_url()"
+                   tal:content="m/Title"/>
+              </td>
+              <td tal:condition="ShowPrices">
+                <span tal:replace="python:currencies[currency].symbol"/>
+                <span tal:replace="python:'%.02f'%dep.getTotalPrice()"/>
+              </td>
+            </tr>
+          </table>
+        </div>
+      </tal:calc>
 
-		</div>
+      <tal:nocalc condition="not:view/calc">
+        <h5>
+          <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/calculation.png"/>
+          <span i18n:translate="">
+            Calculation: None
+          </span>
+        </h5>
+      </tal:nocalc>
 
-	</tal:calc>
+      <tal:parts define="partsetup view/partsetup;
+                         separate view/service/getSeparate;
+                         container view/service/getContainer;
+                         preservation view/service/getPreservation;"
+                 condition="python:(partsetup or separate or container or preservation)">
 
-    <tal:nocalc
-		condition="not:view/calc">
-		<h5>
-			<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/calculation.png"/>
-			<span i18n:translate="">
-				Calculation: None
-			</span>
-		</h5>
-	</tal:nocalc>
-
-    <tal:parts
-		define="partsetup view/partsetup;
-				separate view/service/getSeparate;
-				container view/service/getContainer;
-				preservation view/service/getPreservation;"
-		condition="python:(partsetup or separate or container or preservation)">
-
-		<h5>
-			<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/samplepartition.png"/>
-			<span i18n:translate="">
-				Partition Setup
-			</span>
-		</h5>
+        <h5>
+          <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/samplepartition.png"/>
+          <span i18n:translate="">
+            Partition Setup
+          </span>
+        </h5>
 
         <div id="parts_list" tal:condition="partsetup">
-			<p>
-				<span
-					tal:condition="view/service/getSeparate"
-					i18n:translate="">This service requires a separate container.</span>
-				<span
-					tal:condition="not:view/service/getSeparate"
-					i18n:translate="">This service does not require a separate partition</span>
-			</p>
-			<p>
-				<span
-					tal:condition="container"
-					i18n:translate="">Default containers:
-					<span
-						i18n:name="container_list"
-						tal:replace="python:', '.join(c.Title() for c in container)"/>
-				</span>
-				<span
-					tal:condition="not:container"
-					i18n:translate="">No default containers specified for this service</span>
-			</p>
-			<p>
-				<span
-					tal:condition="preservation"
-					i18n:translate="">Default preservations:
-					<span
-						i18n:name="preservation_list"
-						tal:replace="python:', '.join(p.Title() for p in preservation)"/>
-				</span>
-				<span
-					tal:condition="not:preservation"
-					i18n:translate="">No default preservations specified for this service</span>
-			</p>
+          <p>
+            <span tal:condition="view/service/getSeparate"
+                  i18n:translate="">This service requires a separate container.</span>
+            <span tal:condition="not:view/service/getSeparate"
+                  i18n:translate="">This service does not require a separate partition</span>
+          </p>
+          <p>
+            <span tal:condition="container"
+                  i18n:translate="">Default containers:
+              <span i18n:name="container_list"
+                    tal:replace="python:', '.join(c.Title() for c in container)"/>
+            </span>
+            <span tal:condition="not:container"
+                  i18n:translate="">No default containers specified for this service</span>
+          </p>
+          <p>
+            <span tal:condition="preservation"
+                  i18n:translate="">Default preservations:
+              <span i18n:name="preservation_list"
+                    tal:replace="python:', '.join(p.Title() for p in preservation)"/>
+            </span>
+            <span tal:condition="not:preservation"
+                  i18n:translate="">No default preservations specified for this service</span>
+          </p>
 
-			<h5>
-				<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/sampletype.png"/>
-				<span i18n:translate="">
-					Sample Types
-				</span>
-			</h5>
+          <h5>
+            <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/sampletype.png"/>
+            <span i18n:translate="">
+					    Sample Types
+				    </span>
+			    </h5>
 
-			<table>
-				<tr>
-					<th i18n:translate="">Sample Type</th>
-					<th i18n:translate="">Separate</th>
-					<th i18n:translate="">Preservations</th>
-					<th i18n:translate="">Containers</th>
-					<th i18n:translate="">Volume</th>
-				</tr>
-				<tr tal:repeat="ps partsetup">
-					<td tal:content="ps/sampletype"/>
-					<td tal:content="ps/separate"/>
-					<td tal:content="ps/preservation"/>
-					<td tal:content="ps/container"/>
-					<td tal:content="ps/vol|nothing"/>
-				</tr>
-			</table>
+			    <table>
+				    <tr>
+					    <th i18n:translate="">Sample Type</th>
+					    <th i18n:translate="">Separate</th>
+					    <th i18n:translate="">Preservations</th>
+					    <th i18n:translate="">Containers</th>
+					    <th i18n:translate="">Volume</th>
+				    </tr>
+				    <tr tal:repeat="ps partsetup">
+					    <td tal:content="ps/sampletype"/>
+					    <td tal:content="ps/separate"/>
+					    <td tal:content="ps/preservation"/>
+					    <td tal:content="ps/container"/>
+					    <td tal:content="ps/vol|nothing"/>
+				    </tr>
+			    </table>
+		    </div>
+	    </tal:parts>
 
-		</div>
+      <div id="analysis_log">
+		    <h5>
+			    <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/calendar.png"/>
+			    <span i18n:translate="">Log</span>
+		    </h5>
+		    <table>
+			    <tr>
+				    <th i18n:translate="">Date</th>
+				    <th i18n:translate="">User</th>
+				    <th i18n:translate="">Action</th>
+				    <th i18n:translate="">Description</th>
+			    </tr>
+			    <tr tal:repeat="line view/log">
+				    <td tal:content="line/Date"/>
+				    <td tal:content="line/User"/>
+				    <td tal:content="line/Action"/>
+				    <td tal:content="line/Description"/>
+			    </tr>
+		    </table>
+	    </div>
+    </div>
 
-	</tal:parts>
-
-    <div id="analysis_log">
-		<h5>
-			<img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/calendar.png"/>
-			<span i18n:translate="">Log</span>
-		</h5>
-		<table>
-			<tr>
-				<th i18n:translate="">Date</th>
-				<th i18n:translate="">User</th>
-				<th i18n:translate="">Action</th>
-				<th i18n:translate="">Description</th>
-			</tr>
-			<tr tal:repeat="line view/log">
-				<td tal:content="line/Date"/>
-				<td tal:content="line/User"/>
-				<td tal:content="line/Action"/>
-				<td tal:content="line/Description"/>
-			</tr>
-		</table>
-	</div>
-
-</div>
-
-</body>
+  </body>
 </html>

--- a/bika/lims/browser/templates/analysisservice_popup.pt
+++ b/bika/lims/browser/templates/analysisservice_popup.pt
@@ -87,7 +87,7 @@
              tal:condition="filename"
              tal:define="file method/MethodDocument;
                          filename python:getattr(file, 'filename', '');
-                         filesize python:file.getObjSize();
+                         filesize python:file.get_size() or 0;
                          icon file/icon | nothing;">
           <h5>
             <img tal:attributes="src string:${portal_url}/++resource++bika.lims.images/attachment.png"/>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/383

## Current behavior before PR

Clicking on an Analysis where the method has an attached document raises an Unauthorized Error

## Desired behavior after PR is merged

Analysis Info is displayed properly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
