### PR TITLE
Fix Abbott's m2000 rt import interface tests

### DIFF
--- a/bika/lims/tests/doctests/AbbottM2000rtImportInterface.rst
+++ b/bika/lims/tests/doctests/AbbottM2000rtImportInterface.rst
@@ -171,11 +171,18 @@ Load results test file and import the results::
     ...                                  override=[True, True])
     >>> importer.process()
 
-Check the importer logs to verify that the values were correctly imported::
+Check from the importer logs that the file from where the results have been imported is indeed
+the specified file::
 
-    >>> importer.logs
-    ['Parsing file /home/juan/Dev/NMRL/zinstance/src/bika.lims/bika/lims/tests/files/Results.log.123',
-     'End of file reached successfully: 24 objects, 1 analyses, 24 results',
+    >>> import re
+    >>> matches = re.search('(/bika.lims.+)', importer.logs[0])
+    >>> matches.group(0)
+    '/bika.lims/bika/lims/tests/files/Results.log.123'
+
+Check the rest of the importer logs to verify that the values were correctly imported::
+
+    >>> importer.logs[1:]
+    ['End of file reached successfully: 24 objects, 1 analyses, 24 results',
      'Allowed Analysis Request states: sample_received, attachment_due, to_be_verified',
      'Allowed analysis states: sampled, sample_received, attachment_due, to_be_verified',
      "H2O-0001 result for 'HIV06ml:ASRExpDate': '20141211'",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/458

## Current behavior before PR

Abbott's m2000 rt import interface test failed because there was a check against a hardcoded path that wasn't instance independent 

## Desired behavior after PR is merged

Abbott's m2000 rt import interface test passes

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
