### PR TITLE
Enable classic tests

### DIFF
--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -303,8 +303,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         doesn't allow manual input of detection limits, returns the value set
         by default in the Analysis Service
         """
-        operand = self.getDetectionLimitOperand()
-        if operand and operand == '<':
+        if self.isLowerDetectionLimit():
             result = self.getResult()
             try:
                 # in this case, the result itself is the LDL.
@@ -324,8 +323,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         doesn't allow manual input of detection limits, returns the value set
         by default in the Analysis Service
         """
-        operand = self.getDetectionLimitOperand()
-        if operand and operand == '>':
+        if self.isUpperDetectionLimit():
             result = self.getResult()
             try:
                 # in this case, the result itself is the LDL.
@@ -342,9 +340,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """Returns True if the result is below the Lower Detection Limit or
         if Lower Detection Limit has been manually set
         """
-        dl = self.getDetectionLimitOperand()
-        if dl and dl == '<':
+        if self.isLowerDetectionLimit():
             return True
+
         result = self.getResult()
         if result and str(result).strip().startswith('<'):
             return True
@@ -362,9 +360,9 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """Returns True if the result is above the Upper Detection Limit or
         if Upper Detection Limit has been manually set
         """
-        dl = self.getDetectionLimitOperand()
-        if dl and dl == '>':
+        if self.isUpperDetectionLimit():
             return True
+
         result = self.getResult()
         if result and str(result).strip().startswith('>'):
             return True
@@ -391,18 +389,14 @@ class AbstractAnalysis(AbstractBaseAnalysis):
         """Returns True if the result for this analysis represents a Lower
         Detection Limit. Otherwise, returns False
         """
-        if self.isBelowLowerDetectionLimit():
-            if self.getDetectionLimitOperand() == '<':
-                return True
+        return self.getDetectionLimitOperand() == '<'
 
     @security.public
     def isUpperDetectionLimit(self):
         """Returns True if the result for this analysis represents an Upper
         Detection Limit. Otherwise, returns False
         """
-        if self.isAboveUpperDetectionLimit():
-            if self.getDetectionLimitOperand() == '>':
-                return True
+        return self.getDetectionLimitOperand() == '>'
 
     @security.public
     def getDependents(self):

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -992,7 +992,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             # Is assigned to a worksheet?
             wss = self.getBackReferences('WorksheetAnalysis')
             if len(wss) > 0:
-                analyst = wss[0].getAnalyst()
+                analyst = wss[0].getAnalyst().getUsername()
                 field.set(self, analyst)
         return analyst if analyst else ''
 

--- a/bika/lims/content/samplepoint.py
+++ b/bika/lims/content/samplepoint.py
@@ -142,7 +142,6 @@ class SamplePoint(BaseContent, HistoryAwareMixin):
             return [""]
         return sample_type_titles
 
-    @deprecated("Please use getSampleTypeTitles instead")
     def getSampleTypeTitle(self):
         """Returns a comma separated list of sample type titles
         """

--- a/bika/lims/tests/test_MultiVerificationTypes.py
+++ b/bika/lims/tests/test_MultiVerificationTypes.py
@@ -5,19 +5,15 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-
-from bika.lims.content.analysis import Analysis
-from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
-from bika.lims.tests.base import BikaFunctionalTestCase
-from bika.lims.utils.analysis import create_analysis
-from plone.app.testing import login, logout
-from plone.app.testing import TEST_USER_NAME
-from Products.CMFCore.utils import getToolByName
-from bika.lims.utils import tmpID
 from Products.CMFPlone.utils import _createObjectByType
-from bika.lims.utils.analysisrequest import create_analysisrequest
-
-import unittest
+from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
+from bika.lims.tests.base import BikaFunctionalTestCase
+from bika.lims.utils import tmpID
+from bika.lims.utils.analysis import create_analysis
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
@@ -25,23 +21,23 @@ except ImportError:
     import unittest
 
 
-class Test_MultiVerificationType(BikaFunctionalTestCase):
+class TestMultiVerificationType(BikaFunctionalTestCase):
     """
     In Bika Setup, When Multi verification is enabled, one of 3 types of Multi Verification
     option should be chosen. Functional Testing of this new feature.
     """
-    layer = BIKA_FUNCTIONAL_TESTING
+    layer = BIKA_LIMS_FUNCTIONAL_TESTING
 
     def setUp(self):
-        super(Test_MultiVerificationType, self).setUp()
+        super(TestMultiVerificationType, self).setUp()
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
+        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
     def tearDown(self):
-        logout()
-        super(Test_MultiVerificationType, self).tearDown()
+        super(TestMultiVerificationType, self).tearDown()
 
     def test_MultiVerificationType(self):
-
         #Testing when the same user can verify multiple times
         self.portal.bika_setup.setNumberOfRequiredVerifications(4)
         self.portal.bika_setup.setTypeOfmultiVerification('self_multi_enabled')
@@ -79,6 +75,6 @@ class Test_MultiVerificationType(BikaFunctionalTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(Test_MultiVerificationType))
-    suite.layer = BIKA_FUNCTIONAL_TESTING
+    suite.addTest(unittest.makeSuite(TestMultiVerificationType))
+    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_decimal-sci-notation.py
+++ b/bika/lims/tests/test_decimal-sci-notation.py
@@ -5,14 +5,14 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-
 from Products.CMFCore.utils import getToolByName
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login, logout
-
-from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
 from bika.lims.tests.base import BikaFunctionalTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
@@ -20,13 +20,14 @@ except ImportError: # Python 2.7
     import unittest
 
 
-class Test_DecimalSciNotation(BikaFunctionalTestCase):
-    layer = BIKA_FUNCTIONAL_TESTING
+class TestDecimalSciNotation(BikaFunctionalTestCase):
+    layer = BIKA_LIMS_FUNCTIONAL_TESTING
 
     def setUp(self):
-        super(Test_DecimalSciNotation, self).setUp()
+        super(TestDecimalSciNotation, self).setUp()
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
+        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
-
         # analysis-service-3: Calcium (Ca)
         servs = self.portal.bika_setup.bika_analysisservices
         self.service = servs['analysisservice-3']
@@ -44,8 +45,7 @@ class Test_DecimalSciNotation(BikaFunctionalTestCase):
         self.service.setPrecision(self.orig_as_prec)
         self.service.setExponentialFormatPrecision(self.orig_as_expf)
         self.service.setLowerDetectionLimit(self.orig_as_ldl)
-        logout()
-        super(Test_DecimalSciNotation, self).tearDown()
+        super(TestDecimalSciNotation, self).tearDown()
 
     def test_DecimalSciNotation(self):
         # Notations
@@ -315,7 +315,7 @@ class Test_DecimalSciNotation(BikaFunctionalTestCase):
         s.setLowerDetectionLimit('-99999') # We want to test results below 0 too
         prevm = []
         an = None
-        bs = self.portal.bika_setup;
+        bs = self.portal.bika_setup
         for m in matrix:
             # Create the AR and set the values to the AS, but only if necessary
             if not an or prevm[0] != m[0] or prevm[1] != m[1]:
@@ -335,7 +335,7 @@ class Test_DecimalSciNotation(BikaFunctionalTestCase):
                 wf = getToolByName(ar, 'portal_workflow')
                 wf.doActionFor(ar, 'receive')
                 an = ar.getAnalyses()[0].getObject()
-                prevm = m;
+                prevm = m
             an.setResult(m[3])
 
             self.assertEqual(an.getResult(), m[3])
@@ -346,6 +346,6 @@ class Test_DecimalSciNotation(BikaFunctionalTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(Test_DecimalSciNotation))
-    suite.layer = BIKA_FUNCTIONAL_TESTING
+    suite.addTest(unittest.makeSuite(TestDecimalSciNotation))
+    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_decimalmark-sci-notation.py
+++ b/bika/lims/tests/test_decimalmark-sci-notation.py
@@ -5,16 +5,14 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-
-from bika.lims.content.analysis import Analysis
-from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from Products.CMFCore.utils import getToolByName
+from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
 from bika.lims.tests.base import BikaFunctionalTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from bika.lims.workflow import doActionFor
-from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from Products.CMFCore.utils import getToolByName
-import unittest
+from plone.app.testing import login
+from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
@@ -22,11 +20,13 @@ except ImportError: # Python 2.7
     import unittest
 
 
-class Test_DecimalMarkWithSciNotation(BikaFunctionalTestCase):
-    layer = BIKA_FUNCTIONAL_TESTING
+class TestDecimalMarkWithSciNotation(BikaFunctionalTestCase):
+    layer = BIKA_LIMS_FUNCTIONAL_TESTING
 
     def setUp(self):
-        super(Test_DecimalMarkWithSciNotation, self).setUp()
+        super(TestDecimalMarkWithSciNotation, self).setUp()
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
+        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
         # analysis-service-3: Calcium (Ca)
@@ -48,8 +48,7 @@ class Test_DecimalMarkWithSciNotation(BikaFunctionalTestCase):
         self.service.setExponentialFormatPrecision(self.orig_as_expf)
         self.service.setLowerDetectionLimit(self.orig_as_ldl)
         self.portal.bika_setup.setResultsDecimalMark(self.orig_dm)
-        logout()
-        super(Test_DecimalMarkWithSciNotation, self).tearDown()
+        super(TestDecimalMarkWithSciNotation, self).tearDown()
 
     def test_DecimalMarkWithSciNotation(self):
         # Notations
@@ -101,7 +100,7 @@ class Test_DecimalMarkWithSciNotation(BikaFunctionalTestCase):
         s.setLowerDetectionLimit('-99999') # We want to test results below 0 too
         prevm = []
         an = None
-        bs = self.portal.bika_setup;
+        bs = self.portal.bika_setup
         bs.setResultsDecimalMark(',')
         for m in matrix:
             # Create the AR and set the values to the AS, but only if necessary
@@ -122,7 +121,7 @@ class Test_DecimalMarkWithSciNotation(BikaFunctionalTestCase):
                 wf = getToolByName(ar, 'portal_workflow')
                 wf.doActionFor(ar, 'receive')
                 an = ar.getAnalyses()[0].getObject()
-                prevm = m;
+                prevm = m
             an.setResult(m[3])
 
             self.assertEqual(an.getResult(), m[3])
@@ -133,6 +132,6 @@ class Test_DecimalMarkWithSciNotation(BikaFunctionalTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(Test_DecimalMarkWithSciNotation))
-    suite.layer = BIKA_FUNCTIONAL_TESTING
+    suite.addTest(unittest.makeSuite(TestDecimalMarkWithSciNotation))
+    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_duplicate-analysis.py
+++ b/bika/lims/tests/test_duplicate-analysis.py
@@ -5,18 +5,16 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-
-from bika.lims.content.analysis import Analysis
-from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
+from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
 from bika.lims.tests.base import BikaFunctionalTestCase
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from bika.lims.workflow import doActionFor
-from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import _createObjectByType
-import unittest
+from plone.app.testing import login
+from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
@@ -24,20 +22,21 @@ except ImportError:
     import unittest
 
 
-class Test_LIMS2001(BikaFunctionalTestCase):
+class TestAddDuplicateAnalysis(BikaFunctionalTestCase):
     """
     When adding a duplicate for an AR in a worksheet, only the first analysis
     gets duplicated: https://jira.bikalabs.com/browse/LIMS-2001
     """
-    layer = BIKA_FUNCTIONAL_TESTING
+    layer = BIKA_LIMS_FUNCTIONAL_TESTING
 
     def setUp(self):
-        super(Test_LIMS2001, self).setUp()
+        super(TestAddDuplicateAnalysis, self).setUp()
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
+        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
     def tearDown(self):
-        logout()
-        super(Test_LIMS2001, self).tearDown()
+        super(TestAddDuplicateAnalysis, self).tearDown()
 
     def test_LIMS2001(self):
         # ARs creation
@@ -169,6 +168,6 @@ class Test_LIMS2001(BikaFunctionalTestCase):
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(Test_LIMS2001))
-    suite.layer = BIKA_FUNCTIONAL_TESTING
+    suite.addTest(unittest.makeSuite(TestAddDuplicateAnalysis))
+    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_hiddenanalyses.py
+++ b/bika/lims/tests/test_hiddenanalyses.py
@@ -3,14 +3,13 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from bika.lims.content.analysis import Analysis
-from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
 from bika.lims.tests.base import BikaFunctionalTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from bika.lims.workflow import doActionFor
-from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-import unittest
+from plone.app.testing import login
+from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
@@ -19,11 +18,14 @@ except ImportError: # Python 2.7
 
 
 class TestHiddenAnalyses(BikaFunctionalTestCase):
-    layer = BIKA_FUNCTIONAL_TESTING
+    layer = BIKA_LIMS_FUNCTIONAL_TESTING
 
     def setUp(self):
         super(TestHiddenAnalyses, self).setUp()
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
+        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
+
         servs = self.portal.bika_setup.bika_analysisservices
 
         # analysis-service-3: Calcium (Ca)
@@ -55,7 +57,6 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
         self.analysisprofile.setAnalysisServicesSettings([])
         self.artemplate.setAnalysisServicesSettings([])
 
-        logout()
         super(TestHiddenAnalyses, self).tearDown()
 
     def test_service_hidden_service(self):
@@ -253,7 +254,7 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
 
         # Modify visibility for Calcium in AR
-        uid = self.services[0].UID();
+        uid = self.services[0].UID()
         sets = [{'uid': uid}]
         ar.setAnalysisServicesSettings(sets)
         self.assertFalse(ar.isAnalysisServiceHidden(uid))
@@ -288,7 +289,7 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(uid))
 
         # AR with template with no changes
-        values['Template'] = self.artemplate
+        values['Template'] = self.artemplate.UID()
         del values['Profiles']
         ar = create_analysisrequest(client, request, values, services)
         self.assertFalse('hidden' in ar.getAnalysisServiceSettings(services[0]))
@@ -373,5 +374,5 @@ class TestHiddenAnalyses(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestHiddenAnalyses))
-    suite.layer = BIKA_FUNCTIONAL_TESTING
+    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_limitdetections.py
+++ b/bika/lims/tests/test_limitdetections.py
@@ -370,7 +370,7 @@ class TestLimitDetections(BikaFunctionalTestCase):
                   'Fe': 2} # analysisservice-7
         ans = ar.getAnalyses()
         # Sort them by getKeyword, so we get them in the same order as the ASs
-        ans = sorted(ans, key=lambda x: x.getId)
+        ans = sorted(ans, key=lambda x: x.getKeyword)
         for a in ans:
             an = a.getObject()
             idx = asidxs[an.id]

--- a/bika/lims/tests/test_limitdetections.py
+++ b/bika/lims/tests/test_limitdetections.py
@@ -3,16 +3,14 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from bika.lims import logger
-from bika.lims.content.analysis import Analysis
-from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from Products.CMFCore.utils import getToolByName
+from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
 from bika.lims.tests.base import BikaFunctionalTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from bika.lims.workflow import doActionFor
-from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-from Products.CMFCore.utils import getToolByName
-import unittest
+from plone.app.testing import login
+from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
@@ -21,10 +19,12 @@ except ImportError: # Python 2.7
 
 
 class TestLimitDetections(BikaFunctionalTestCase):
-    layer = BIKA_FUNCTIONAL_TESTING
+    layer = BIKA_LIMS_FUNCTIONAL_TESTING
 
     def setUp(self):
         super(TestLimitDetections, self).setUp()
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
+        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
         servs = self.portal.bika_setup.bika_analysisservices
         # analysis-service-3: Calcium (Ca)
@@ -50,7 +50,6 @@ class TestLimitDetections(BikaFunctionalTestCase):
             s.setAllowManualDetectionLimit(False)
             s.setLowerDetectionLimit(str(0))
             s.setUpperDetectionLimit(str(1000))
-        logout()
         super(TestLimitDetections, self).tearDown()
 
     def test_ar_manage_results_detectionlimit_selector_manual(self):
@@ -366,10 +365,13 @@ class TestLimitDetections(BikaFunctionalTestCase):
         ar = create_analysisrequest(client, request, values, services)
 
         # Basic detection limits
-        asidxs = {'analysisservice-3': 0,
-                  'analysisservice-6': 1,
-                  'analysisservice-7': 2}
-        for a in ar.getAnalyses():
+        asidxs = {'Ca': 0, # analysisservice-3
+                  'Cu': 1, # analysisservice-6
+                  'Fe': 2} # analysisservice-7
+        ans = ar.getAnalyses()
+        # Sort them by getKeyword, so we get them in the same order as the ASs
+        ans = sorted(ans, key=lambda x: x.getId)
+        for a in ans:
             an = a.getObject()
             idx = asidxs[an.id]
             self.assertEqual(an.getLowerDetectionLimit(), float(self.lds[idx]['min']))
@@ -483,5 +485,5 @@ class TestLimitDetections(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestLimitDetections))
-    suite.layer = BIKA_FUNCTIONAL_TESTING
+    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_manualuncertainty.py
+++ b/bika/lims/tests/test_manualuncertainty.py
@@ -3,14 +3,13 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from bika.lims.content.analysis import Analysis
-from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
 from bika.lims.tests.base import BikaFunctionalTestCase
 from bika.lims.utils.analysisrequest import create_analysisrequest
-from bika.lims.workflow import doActionFor
-from plone.app.testing import login, logout
+from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
-import unittest
+from plone.app.testing import login
+from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
@@ -19,11 +18,14 @@ except ImportError: # Python 2.7
 
 
 class TestManualUncertainty(BikaFunctionalTestCase):
-    layer = BIKA_FUNCTIONAL_TESTING
+    layer = BIKA_LIMS_FUNCTIONAL_TESTING
 
     def setUp(self):
         super(TestManualUncertainty, self).setUp()
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
+        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
+
         servs = self.portal.bika_setup.bika_analysisservices
         # analysis-service-3: Calcium (Ca)
         # analysis-service-6: Cooper (Cu)
@@ -45,7 +47,7 @@ class TestManualUncertainty(BikaFunctionalTestCase):
             s.setAllowManualUncertainty(False)
             s.setUncertainties([])
             s.setPrecisionFromUncertainty(False)
-        logout()
+
         super(TestManualUncertainty, self).tearDown()
 
     def test_set_manualuncertainty_field(self):
@@ -207,5 +209,5 @@ class TestManualUncertainty(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestManualUncertainty))
-    suite.layer = BIKA_FUNCTIONAL_TESTING
+    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/tests/test_reflexrules.py
+++ b/bika/lims/tests/test_reflexrules.py
@@ -1,11 +1,13 @@
-from plone.app.testing import TEST_USER_NAME
-from plone.app.testing import login, logout
-
 from bika.lims.idserver import renameAfterCreation
-from bika.lims.testing import BIKA_FUNCTIONAL_TESTING
+from bika.lims.testing import BIKA_LIMS_FUNCTIONAL_TESTING
 from bika.lims.tests.base import BikaFunctionalTestCase
 from bika.lims.utils import tmpID
 from bika.lims.utils.analysisrequest import create_analysisrequest
+from bika.lims.workflow import doActionFor
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
+from plone.app.testing import login
+from plone.app.testing import setRoles
 
 try:
     import unittest2 as unittest
@@ -15,7 +17,7 @@ except ImportError:  # Python 2.7
 
 # Tests related with reflex testing
 class TestReflexRules(BikaFunctionalTestCase):
-    layer = BIKA_FUNCTIONAL_TESTING
+    layer = BIKA_LIMS_FUNCTIONAL_TESTING
     # A list with the created rules
     rules_list = []
     # A list with the created methods
@@ -187,10 +189,11 @@ class TestReflexRules(BikaFunctionalTestCase):
 
     def setUp(self):
         super(TestReflexRules, self).setUp()
+        setRoles(self.portal, TEST_USER_ID, ['Member', 'LabManager'])
+        self.setup_data_load()
         login(self.portal, TEST_USER_NAME)
 
     def tearDown(self):
-        logout()
         super(TestReflexRules, self).tearDown()
 
     def test_reflex_rule_set_get(self):
@@ -276,8 +279,7 @@ class TestReflexRules(BikaFunctionalTestCase):
                   'SampleType': sampletype.UID()}
         request = {}
         ar = create_analysisrequest(client, request, values, [ans_list[-1]])
-        wf = getToolByName(ar, 'portal_workflow')
-        wf.doActionFor(ar, 'receive')
+        doActionFor(ar, 'receive')
         # Getting the analysis
         analysis = ar.getAnalyses(full_objects=True)[0]
         # Testing reflexrule content type public functions
@@ -894,5 +896,5 @@ class TestReflexRules(BikaFunctionalTestCase):
 def test_suite():
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(TestReflexRules))
-    suite.layer = BIKA_FUNCTIONAL_TESTING
+    suite.layer = BIKA_LIMS_FUNCTIONAL_TESTING
     return suite

--- a/bika/lims/utils/analysisrequest.py
+++ b/bika/lims/utils/analysisrequest.py
@@ -7,8 +7,6 @@ from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import safe_unicode
 from bika.lims import bikaMessageFactory as _
 from bika.lims import logger
-from bika.lims.browser.analysisrequest.reject import \
-    AnalysisRequestRejectPdfView, AnalysisRequestRejectEmailView
 from bika.lims.idserver import renameAfterCreation
 from bika.lims.interfaces import ISample, IAnalysisService, IRoutineAnalysis
 from bika.lims.utils import tmpID
@@ -311,6 +309,12 @@ def notify_rejection(analysisrequest):
     :param analysisrequest: Analysis Request to which the notification refers
     :returns: true if success
     """
+
+    # We do this imports here to avoid circular dependencies until we deal
+    # better with this notify_rejection thing.
+    from bika.lims.browser.analysisrequest.reject import \
+        AnalysisRequestRejectPdfView, AnalysisRequestRejectEmailView
+
     arid = analysisrequest.getId()
 
     # This is the template to render for the pdf that will be either attached


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

With this Pull Requests, the following "classic" tests have been revisited and included in default's testsuite:

  * TestManualUncertainty
  * TestDecimalSciNotation
  * TestDecimalMarkSciNotation
  * TestHiddenAnalyses
  * TestMultiVerificationTypes
  * TestReflexRules
  * TestAddDuplicateAnalysis

Although these tests are slower than doctests (mainly because all them rely on the import of setupdata), I think that is better to include than exclude them, specially because the tests are run by Travis, so we don't need to care about the time they take. This being said, is obvious to me that would be nice to eventually port them to doctests or make the function `setup_data_load()` to fill data without relying on the setup import machinery.

A part from these tests, small changes in AbstractAnalysis have been done to simplify the checks of Detection Limits and a hidden bug in `getAnalyst` has been fixed too.

```
$ bin/test -m bika.lims
Running bika.lims.testing.BikaLIMSLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.297 seconds.
  Set up plone.app.testing.layers.PloneFixture in 11.451 seconds.
  Set up bika.lims.testing.BikaLIMSLayer in 19.320 seconds.
  Set up bika.lims.testing.BikaLIMSLayer:Functional in 0.000 seconds.
                  
  Ran 42 tests with 0 failures and 0 errors in 44 minutes 53.954 seconds.
Tearing down left over layers:
  Tear down bika.lims.testing.BikaLIMSLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaLIMSLayer in 0.004 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.051 seconds.
  Tear down plone.testing.z2.Startup in 0.004 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.009 seconds.

The command "bin/test -m bika.lims" exited with 0.
```

## Current behavior before PR

The tests above are not run against new Pull Requests

## Desired behavior after PR is merged

The tests above are run against new Pull Requests

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
