### PR TITLE
Log warning instead of error when resolving UIDReference fails on retrieving analyses from Sample Partition

### DIFF
--- a/bika/lims/browser/fields/uidreferencefield.py
+++ b/bika/lims/browser/fields/uidreferencefield.py
@@ -56,7 +56,7 @@ class UIDReferenceField(StringField):
             return None
         obj = _get_object(context, value)
         if obj is None:
-            logger.error(
+            logger.warning(
                 "{}.{}: Resolving UIDReference failed for {}.  No object will "
                 "be returned.".format(context, self.getName(), value))
         return obj


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

There are some punctual cases in which the following error is logged: 

```<SamplePartition at H20-0001-P1>.Analyses: Resolving UIDReference failed for ac5c81bed80149108az23bd1ac0d502c.  No object will be returned.```

It is believed that initial transitions of Sample (e.g. ```registered```, ```received```) happen during the object creation process by Plone. At that moment, objects (```SamplePartition```) don't have any Analyses assigned yet and this error is logged. However, the error is only logged and the user doesn't expect/see any bad behavior. For this reason, it has been decided that the best choice is to **temporarily use a warning instead of an error**.

## Current behavior before PR

An error is logged when resolving an UIDReference fails on retrieving analyses from a Sample Partition.

## Desired behavior after PR is merged 

A warning is logged when resolving an UIDReference fails on retrieving analyses from a Sample Partition.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
