### PR TITLE
Issue-468: Remove unique field validator for batch titles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 
 **Changed**
 
+- #469 Remove unique field validator for Batch titles
 - #459 PR-1942 Feature/instrument certification interval refactoring
 - #431 Make ARAnalysesField setter to accept Analysis/Service objects
 

--- a/bika/lims/content/batch.py
+++ b/bika/lims/content/batch.py
@@ -5,33 +5,36 @@
 
 from AccessControl import ClassSecurityInfo
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
+from bika.lims import deprecated
+from bika.lims.browser.widgets import RecordsWidget as bikaRecordsWidget
+from bika.lims.browser.widgets import DateTimeWidget, ReferenceWidget
+from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaFolderSchema
-from bika.lims.interfaces import IBatch, IClient
-from bika.lims.workflow import skip, BatchState, StateFlow, getCurrentState,\
-    CancellationState
-from bika.lims.browser.widgets import DateTimeWidget
-from plone import api
+from bika.lims.interfaces import IBatch, IBatchSearchableText, IClient
+from bika.lims.workflow import (BatchState, CancellationState, StateFlow,
+                                getCurrentState)
 from plone.app.folder.folder import ATFolder
-from Products.Archetypes.public import *
-from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import safe_unicode
-from zope.interface import implements
-from bika.lims.permissions import EditBatch
 from plone.indexer import indexer
+from Products.Archetypes.public import (DateTimeField, DisplayList, LinesField,
+                                        MultiSelectionWidget, ReferenceField,
+                                        Schema, StringField, StringWidget,
+                                        TextAreaWidget, TextField,
+                                        registerType)
 from Products.Archetypes.references import HoldingReference
 from Products.ATExtensions.ateapi import RecordsField
-from bika.lims.catalog import CATALOG_ANALYSIS_REQUEST_LISTING
-from bika.lims.browser.widgets import RecordsWidget as bikaRecordsWidget
-
-from bika.lims.browser.widgets import ReferenceWidget
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 from zope.component import getAdapters
-from bika.lims.interfaces import IBatchSearchableText
+from zope.interface import implements
+
+
+@indexer(IBatch)
+def BatchDate(instance):
+    return instance.Schema().getField('BatchDate').get(instance)
 
 
 class InheritedObjectsUIField(RecordsField):
-
     """XXX bika.lims.RecordsWidget doesn't cater for multiValued fields
     InheritedObjectsUI is a RecordsField because we want the RecordsWidget,
     but the values are stored in ReferenceField 'InheritedObjects'
@@ -68,15 +71,20 @@ class InheritedObjectsUIField(RecordsField):
 
 
 schema = BikaFolderSchema.copy() + Schema((
+
     StringField(
         'BatchID',
         required=False,
         validators=('uniquefieldvalidator',),
         widget=StringWidget(
+            # XXX This field can never hold a user value, because it is
+            #     invisible (see custom getBatchID getter method)
+            # => we should remove that field
             visible=False,
             label=_("Batch ID"),
         )
     ),
+
     ReferenceField(
         'Client',
         required=0,
@@ -88,12 +96,14 @@ schema = BikaFolderSchema.copy() + Schema((
             visible=True,
             base_query={'inactive_state': 'active'},
             showOn=True,
-            colModel=[{'columnName': 'UID', 'hidden': True},
-                      {'columnName': 'Title', 'width': '60', 'label': _('Title')},
-                      {'columnName': 'ClientID', 'width': '20', 'label': _('Client ID')}
-                     ],
-      ),
+            colModel=[
+                {'columnName': 'UID', 'hidden': True},
+                {'columnName': 'Title', 'width': '60', 'label': _('Title')},
+                {'columnName': 'ClientID', 'width': '20', 'label': _('Client ID')}
+            ],
+        ),
     ),
+
     StringField(
         'ClientBatchID',
         required=0,
@@ -101,6 +111,7 @@ schema = BikaFolderSchema.copy() + Schema((
             label=_("Client Batch ID")
         )
     ),
+
     DateTimeField(
         'BatchDate',
         required=False,
@@ -108,6 +119,7 @@ schema = BikaFolderSchema.copy() + Schema((
             label=_('Date'),
         ),
     ),
+
     LinesField(
         'BatchLabels',
         vocabulary="BatchLabelVocabulary",
@@ -117,6 +129,7 @@ schema = BikaFolderSchema.copy() + Schema((
             format="checkbox",
         )
     ),
+
     TextField(
         'Remarks',
         default_content_type='text/x-web-intelligent',
@@ -128,31 +141,37 @@ schema = BikaFolderSchema.copy() + Schema((
             append_only=True,
         )
     ),
+
     ReferenceField(
         'InheritedObjects',
         required=0,
         multiValued=True,
         allowed_types=('AnalysisRequest'),  # batches are expanded on save
-        referenceClass = HoldingReference,
-        relationship = 'BatchInheritedObjects',
+        referenceClass=HoldingReference,
+        relationship='BatchInheritedObjects',
         widget=ReferenceWidget(
             visible=False,
         ),
     ),
+
     InheritedObjectsUIField(
         'InheritedObjectsUI',
         required=False,
         type='InheritedObjects',
         subfields=('Title', 'ObjectID', 'Description'),
-        subfield_sizes = {'Title': 25,
-                          'ObjectID': 25,
-                          'Description': 50,
-                          },
-        subfield_labels = {'Title': _('Title'),
-                           'ObjectID': _('Object ID'),
-                           'Description': _('Description')
-                           },
-        widget = bikaRecordsWidget(
+        subfield_sizes={
+            'Title': 25,
+            'ObjectID': 25,
+            'Description': 50,
+        },
+
+        subfield_labels={
+            'Title': _('Title'),
+            'ObjectID': _('Object ID'),
+            'Description': _('Description')
+        },
+
+        widget=bikaRecordsWidget(
             label=_("Inherit From"),
             description=_(
                 "Include all analysis requests belonging to the selected objects."),
@@ -189,8 +208,7 @@ schema = BikaFolderSchema.copy() + Schema((
             },
         ),
     ),
-)
-)
+))
 
 # Remove implicit `uniquefieldvalidator` coming from `BikaFolderSchema`
 schema['title'].validators = ()
@@ -210,11 +228,13 @@ schema.moveField('Client', after='title')
 
 
 class Batch(ATFolder):
+    """A Batch combines multiple ARs into a logical unit
+    """
     implements(IBatch)
-    security = ClassSecurityInfo()
-    displayContentsTab = False
-    schema = schema
 
+    schema = schema
+    displayContentsTab = False
+    security = ClassSecurityInfo()
     _at_rename_after_creation = True
 
     def _renameAfterCreation(self, check_auto_id=False):
@@ -222,22 +242,24 @@ class Batch(ATFolder):
         renameAfterCreation(self)
 
     def Title(self):
-        """ Return the Batch ID if title is not defined """
+        """Return the Batch ID if title is not defined
+        """
         titlefield = self.Schema().getField('title')
         if titlefield.widget.visible:
             return safe_unicode(self.title).encode('utf-8')
         else:
             return safe_unicode(self.id).encode('utf-8')
 
+    @deprecated("This method will be removed in senaite.core 1.2.0")
     def _getCatalogTool(self):
         from bika.lims.catalog import getCatalog
         return getCatalog(self)
 
     def getClient(self):
-        """ Retrieves the Client for which the current Batch is attached to
-            Tries to retrieve the Client from the Schema property, but if not
-            found, searches for linked ARs and retrieve the Client from the
-            first one. If the Batch has no client, returns None.
+        """Retrieves the Client for which the current Batch is attached to
+           Tries to retrieve the Client from the Schema property, but if not
+           found, searches for linked ARs and retrieve the Client from the
+           first one. If the Batch has no client, returns None.
         """
         client = self.Schema().getField('Client').get(self)
         if client:
@@ -283,7 +305,10 @@ class Batch(ATFolder):
 
     security.declarePublic('getBatchID')
 
+    @deprecated("Please use getId instead")
     def getBatchID(self):
+        # NOTE This method is a custom getter of the invisible field "BatchID".
+        #      Therefore, it is unlikely that it returns anything else than `getId`.
         if self.BatchID:
             return self.BatchID
         if self.checkCreationFlag():
@@ -291,7 +316,8 @@ class Batch(ATFolder):
         return self.getId()
 
     def BatchLabelVocabulary(self):
-        """ return all batch labels """
+        """Return all batch labels as a display list
+        """
         bsc = getToolByName(self, 'bika_setup_catalog')
         ret = []
         for p in bsc(portal_type='BatchLabel',
@@ -301,7 +327,7 @@ class Batch(ATFolder):
         return DisplayList(ret)
 
     def getAnalysisRequestsBrains(self, **kwargs):
-        """ Return all the Analysis Requests brains linked to the Batch
+        """Return all the Analysis Requests brains linked to the Batch
         kargs are passed directly to the catalog.
         """
         kwargs['getBatchUID'] = self.UID()
@@ -310,14 +336,14 @@ class Batch(ATFolder):
         return brains
 
     def getAnalysisRequests(self, **kwargs):
-        """ Return all the Analysis Requests objects linked to the Batch
-        kargs are passed directly to the catalog.
+        """Return all the Analysis Requests objects linked to the Batch kargs
+        are passed directly to the catalog.
         """
         brains = self.getAnalysisRequestsBrains(**kwargs)
         return [b.getObject() for b in brains]
 
     def isOpen(self):
-        """ Returns true if the Batch is in 'open' state
+        """Returns true if the Batch is in 'open' state
         """
         revstatus = getCurrentState(self, StateFlow.review)
         canstatus = getCurrentState(self, StateFlow.cancellation)
@@ -331,11 +357,11 @@ class Batch(ATFolder):
         return labels
 
     def workflow_guard_open(self):
-        """ Permitted if current review_state is 'closed' or 'cancelled'
-            The open transition is already controlled by 'Bika: Reopen Batch'
-            permission, but left here for security reasons and also for the
-            capability of being expanded/overrided by child products or
-            instance-specific-needs.
+        """Permitted if current review_state is 'closed' or 'cancelled'
+           The open transition is already controlled by 'Bika: Reopen Batch'
+           permission, but left here for security reasons and also for the
+           capability of being expanded/overrided by child products or
+           instance-specific-needs.
         """
         revstatus = getCurrentState(self, StateFlow.review)
         canstatus = getCurrentState(self, StateFlow.cancellation)
@@ -343,11 +369,11 @@ class Batch(ATFolder):
             and canstatus == CancellationState.active
 
     def workflow_guard_close(self):
-        """ Permitted if current review_state is 'open'.
-            The close transition is already controlled by 'Bika: Close Batch'
-            permission, but left here for security reasons and also for the
-            capability of being expanded/overrided by child products or
-            instance-specific needs.
+        """Permitted if current review_state is 'open'.
+           The close transition is already controlled by 'Bika: Close Batch'
+           permission, but left here for security reasons and also for the
+           capability of being expanded/overrided by child products or
+           instance-specific needs.
         """
         revstatus = getCurrentState(self, StateFlow.review)
         canstatus = getCurrentState(self, StateFlow.cancellation)
@@ -355,8 +381,7 @@ class Batch(ATFolder):
             and canstatus == CancellationState.active
 
     def SearchableText(self):
-        """
-        Override searchable text logic based on the requirements.
+        """Override searchable text logic based on the requirements.
 
         This method constructs a text blob which contains all full-text
         searchable text for this content item.
@@ -380,9 +405,8 @@ class Batch(ATFolder):
             entries += adapter.get_plain_text_fields()
 
         def read(accessor):
-            """
-            Call a class accessor method to give a value for certain Archetypes
-            field.
+            """Call a class accessor method to give a value for certain
+            Archetypes field.
             """
             try:
                 value = accessor()
@@ -410,9 +434,5 @@ class Batch(ATFolder):
         # Concatenate all strings to one text blob
         return " ".join(entries)
 
+
 registerType(Batch, PROJECTNAME)
-
-
-@indexer(IBatch)
-def BatchDate(instance):
-    return instance.Schema().getField('BatchDate').get(instance)

--- a/bika/lims/content/batch.py
+++ b/bika/lims/content/batch.py
@@ -192,8 +192,10 @@ schema = BikaFolderSchema.copy() + Schema((
 )
 )
 
-schema['BatchID'].widget.description = _("If no value is entered, the Batch ID"
-                                         " will be auto-generated.")
+# Remove implicit `uniquefieldvalidator` coming from `BikaFolderSchema`
+schema['title'].validators = ()
+schema['title'].widget.description = _("If no value is entered, the Batch ID"
+                                       " will be auto-generated.")
 schema['title'].required = False
 schema['title'].widget.visible = True
 schema['title'].widget.description = _("If no Title value is entered,"

--- a/bika/lims/content/bikaschema.py
+++ b/bika/lims/content/bikaschema.py
@@ -46,8 +46,3 @@ BikaFolderSchema['constrainTypesMode'].schemata = 'settings'
 BikaFolderSchema['locallyAllowedTypes'].widget.visible = False
 BikaFolderSchema['immediatelyAddableTypes'].widget.visible = False
 BikaFolderSchema['constrainTypesMode'].widget.visible = False
-
-
-BikaFolderSchema['title'].validators = ('uniquefieldvalidator',)
-# Update the validation layer after change the validator in runtime
-BikaFolderSchema['title']._validationLayer()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/468

## Current behavior before PR

The title of batches has to be unique

## Desired behavior after PR is merged

The title of batches does not have to be unique 

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
