### PR TITLE
Due to redirection, children classes crash calling AnalysisRequestViewView class

### DIFF
--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -35,12 +35,18 @@ class AnalysisRequestViewView(BrowserView):
     messages = []
 
     def __init__(self, context, request):
-        self.init__ = super(AnalysisRequestViewView, self).__init__(context,
-                                                                    request)
+        super(AnalysisRequestViewView, self).__init__(context, request)
         self.icon = self.portal_url + "/++resource++bika.lims.images/analysisrequest_big.png"
         self.messages = []
 
+    def before_call(self):
+        return True
+
+    def after_call(self):
+        return True
+
     def __call__(self):
+        self.before_call()
         ar = self.context
         workflow = getToolByName(self.context, 'portal_workflow')
         if 'transition' in self.request.form:
@@ -161,6 +167,7 @@ class AnalysisRequestViewView(BrowserView):
                         'Request ${retracted_request_id}.',
                         mapping={'retracted_request_id': par.getId()})
             self.addMessage(message, 'info')
+        self.after_call()
         self.renderMessages()
         return self.template()
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

AnalysisRequestViewView `__call__` method returns html code (string) or `None` depending on whether there is a http redirection.

## Current behavior before PR

If there is a redirection, father class returns `None` and children classes crash because they are trying to render the page calling `self.template()` while nothing has been set up.

## Desired behavior after PR is merged

Two class methods will allow developers to run logic before and after the father `__call__`

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
