### PR TITLE
Issue-474: Fixed AttributeError on WS Analyses assignment

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Changelog
 
 **Fixed**
 
+- #475 Assigning Analyses to a WS raises AttributeError
 - #466 UnicodeDecodeError if unicode characters are entered into the title field
 - #453 Sample points do not show the referenced sample types in view
 - #470 Sort order of Analyses in WS print view wrong

--- a/bika/lims/content/abstractanalysis.py
+++ b/bika/lims/content/abstractanalysis.py
@@ -992,7 +992,7 @@ class AbstractAnalysis(AbstractBaseAnalysis):
             # Is assigned to a worksheet?
             wss = self.getBackReferences('WorksheetAnalysis')
             if len(wss) > 0:
-                analyst = wss[0].getAnalyst().getUsername()
+                analyst = wss[0].getAnalyst()
                 field.set(self, analyst)
         return analyst if analyst else ''
 

--- a/bika/lims/tests/test_duplicate-analysis.py
+++ b/bika/lims/tests/test_duplicate-analysis.py
@@ -72,7 +72,7 @@ class TestAddDuplicateAnalysis(BikaFunctionalTestCase):
         lab_contact = [o for o in lab_contacts if o.getUsername() == 'analyst1']
         self.assertEquals(len(lab_contact), 1)
         lab_contact = lab_contact[0]
-        ws.setAnalyst(lab_contact)
+        ws.setAnalyst(lab_contact.getUsername())
         ws.setResultsLayout(self.portal.bika_setup.getWorksheetLayout())
         # Add analyses into the worksheet
         self.request['context_uid'] = ws.UID()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/474

## Current behavior before PR

Traceback occurs when assigning Analyses to a Workshett

## Desired behavior after PR is merged

Analyses can be assigned

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
