### PR TITLE
ARAnalysisField Setter fails when Analysis objects are sent.

### DIFF
--- a/bika/lims/browser/fields/aranalysesfield.py
+++ b/bika/lims/browser/fields/aranalysesfield.py
@@ -237,7 +237,7 @@ class ARAnalysesField(ObjectField):
         if IAnalysisService.providedBy(obj):
             return api.get_uid(obj)
 
-        if IAnalysis.providedBy(obj) and IRequestAnalysis.providedBy(obj):
+        if IAnalysis.providedBy(obj) or IRequestAnalysis.providedBy(obj):
             return obj.getServiceUID()
 
         # An object, but neither an Analysis nor AnalysisService?


### PR DESCRIPTION
## Current behavior before PR
When Analysis objects are sent to `ARAnalyses` field setter, it fails because of wrong if condition.

## Desired behavior after PR is merged
ARAnalyses field accept Analysis objects and sets properly.
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
