### PR TITLE
Worksheet Templates selection list is empty in Worksheets view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #489 Worksheet Templates selection list is empty in Worksheets view
 - #475 Assigning Analyses to a WS raises AttributeError
 - #466 UnicodeDecodeError if unicode characters are entered into the title field
 - #453 Sample points do not show the referenced sample types in view

--- a/bika/lims/browser/worksheet/views/folder.py
+++ b/bika/lims/browser/worksheet/views/folder.py
@@ -5,32 +5,25 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from DateTime import DateTime
-from DocumentTemplate import sequence
+import json
+
 from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.Archetypes.public import DisplayList
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import _createObjectByType
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+from bika.lims import PMF
+from bika.lims import api
+from bika.lims import bikaMessageFactory as _
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.catalog import CATALOG_WORKSHEET_LISTING
+from bika.lims.permissions import EditWorksheet
+from bika.lims.permissions import ManageWorksheets
+from bika.lims.utils import getUsers
+from bika.lims.utils import to_utf8 as _c
+from bika.lims.utils import user_fullname, get_display_list
 from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.layout.globals.interfaces import IViewView
 from zope.interface import implements
-from bika.lims.utils import user_fullname, get_display_list
-from bika.lims import api
-from bika.lims import bikaMessageFactory as _
-from bika.lims import PMF, logger
-from bika.lims.browser import BrowserView
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.browser.bika_listing import WorkflowAction
-from bika.lims.permissions import EditWorksheet
-from bika.lims.permissions import ManageWorksheets
-from bika.lims.utils import getUsers, tmpID, t
-from bika.lims.utils import to_utf8 as _c
-from bika.lims.catalog import CATALOG_WORKSHEET_LISTING
-import logging
-import plone
-import json
-import zope
 
 
 class FolderView(BikaListingView):

--- a/bika/lims/utils/__init__.py
+++ b/bika/lims/utils/__init__.py
@@ -829,3 +829,32 @@ def is_bika_installed():
     """
     qi = api.portal.get_tool("portal_quickinstaller")
     return qi.isProductInstalled("bika.lims")
+
+
+def get_display_list(brains_or_objects=None, none_item=False):
+    """
+    Returns a DisplayList with the items sorted by Title
+    :param brains_or_objects: list of brains or objects
+    :param none_item: adds an item with empty uid and text "Select.." in pos 0
+    :return: DisplayList (uid, title) sorted by title ascending
+    :rtype: DisplayList
+    """
+    if brains_or_objects is None:
+        return get_display_list(list(), none_item)
+
+    items = list()
+    for brain in brains_or_objects:
+        uid = api.get_uid(brain)
+        if not uid:
+            continue
+        title = api.get_title(brain)
+        items.append((uid, title))
+
+    # Sort items by title ascending
+    items.sort(lambda x, y: cmp(x[1], y[1]))
+
+    # Add the first item?
+    if none_item:
+        items.insert(0, ('', t('Select...')))
+
+    return DisplayList(items)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: [#484 Worksheet Templates selection list is empty in Worksheets view](https://github.com/senaite/bika.lims/issues/484)

## Current behavior before PR

The selection list of Worksheet Templates doesn't get populated with available Worksheet Templates.

## Desired behavior after PR is merged

The selection list of Worksheet Templates does get populated with available Worksheet Templates.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
