### PR TITLE
Bugfix/issue 491 ar add form does not set cc contacts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #491 Fix AR Add Form: CC Contacts not set on Contact Change
 - #475 Assigning Analyses to a WS raises AttributeError
 - #466 UnicodeDecodeError if unicode characters are entered into the title field
 - #453 Sample points do not show the referenced sample types in view

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,7 +21,7 @@ Changelog
 
 **Fixed**
 
-- #491 Fix AR Add Form: CC Contacts not set on Contact Change
+- #492 Fix AR Add Form: CC Contacts not set on Contact Change
 - #475 Assigning Analyses to a WS raises AttributeError
 - #466 UnicodeDecodeError if unicode characters are entered into the title field
 - #453 Sample points do not show the referenced sample types in view

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -972,10 +972,22 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
     def get_contact_info(self, obj):
         """Returns the client info of an object
         """
+
         info = self.get_base_info(obj)
         fullname = obj.getFullname()
         email = obj.getEmailAddress()
-        cccontacts = map(self.get_base_info, obj.getCCContact())
+
+        # Note: It might get a circular dependency when calling:
+        #       map(self.get_contact_info, obj.getCCContact())
+        cccontacts = {}
+        for contact in obj.getCCContact():
+            uid = api.get_uid(contact)
+            fullname = contact.getFullname()
+            email = contact.getEmailAddress()
+            cccontacts[uid] = {
+                "fullname": fullname,
+                "email": email
+            }
 
         info.update({
             "fullname": fullname,

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -969,6 +969,23 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         return info
 
     @cache(cache_key)
+    def get_contact_info(self, obj):
+        """Returns the client info of an object
+        """
+        info = self.get_base_info(obj)
+        fullname = obj.getFullname()
+        email = obj.getEmailAddress()
+        cccontacts = map(self.get_base_info, obj.getCCContact())
+
+        info.update({
+            "fullname": fullname,
+            "email": email,
+            "cccontacts": cccontacts,
+        })
+
+        return info
+
+    @cache(cache_key)
     def get_service_info(self, obj):
         """Returns the info for a Service
         """
@@ -1333,6 +1350,8 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
             # Mapping of client UID -> client object info
             client_metadata = {}
+            # Mapping of contact UID -> contact object info
+            contact_metadata = {}
             # Mapping of sample UID -> sample object info
             sample_metadata = {}
             # Mapping of sampletype UID -> sampletype object info
@@ -1368,6 +1387,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
             # Internal mappings of UID -> object of selected items in this record
             _clients = self.get_objs_from_record(record, "Client_uid")
+            _contacts = self.get_objs_from_record(record, "Contact_uid")
             _specifications = self.get_objs_from_record(record, "Specification_uid")
             _templates = self.get_objs_from_record(record, "Template_uid")
             _samples = self.get_objs_from_record(record, "Sample_uid")
@@ -1381,6 +1401,13 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 metadata = self.get_client_info(obj)
                 # remember the sampletype metadata
                 client_metadata[uid] = metadata
+
+            # CONTACTS
+            for uid, obj in _contacts.iteritems():
+                # get the client metadata
+                metadata = self.get_contact_info(obj)
+                # remember the sampletype metadata
+                contact_metadata[uid] = metadata
 
             # SPECIFICATIONS
             for uid, obj in _specifications.iteritems():
@@ -1537,6 +1564,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             # All relevant form data will be set accoriding to this data.
             out[n] = {
                 "client_metadata": client_metadata,
+                "contact_metadata": contact_metadata,
                 "sample_metadata": sample_metadata,
                 "sampletype_metadata": sampletype_metadata,
                 "dms_metadata": dms_metadata,

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -494,11 +494,10 @@
       var field, me;
       me = this;
       field = $("#CCContact-" + arnum);
-      return $.each(contact.cccontacts, function(index, cccontact) {
-        var title, uid;
-        uid = cccontact.uid;
-        title = cccontact.title;
-        return me.set_reference_field(field, uid, title);
+      return $.each(contact.cccontacts, function(uid, cccontact) {
+        var fullname;
+        fullname = cccontact.fullname;
+        return me.set_reference_field(field, uid, fullname);
       });
     };
 

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1193,14 +1193,15 @@
           _field = _el.find("input[type=text]");
           me.flush_reference_field(_field);
           if (mvl.length > 0) {
-            return $.each(mvl.children(), function(idx, item) {
+            $.each(mvl.children(), function(idx, item) {
               uid = $(item).attr("uid");
               value = $(item).text();
               return me.set_reference_field(_field, uid, value);
             });
           } else {
-            return me.set_reference_field(_field, uid, value);
+            me.set_reference_field(_field, uid, value);
           }
+          return $(_field).trigger("change");
         });
         $(me).trigger("form:changed");
         return;

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -29,6 +29,7 @@
       this.on_analysis_lock_button_click = bind(this.on_analysis_lock_button_click, this);
       this.on_analysis_details_click = bind(this.on_analysis_details_click, this);
       this.on_analysis_specification_changed = bind(this.on_analysis_specification_changed, this);
+      this.on_contact_changed = bind(this.on_contact_changed, this);
       this.on_client_changed = bind(this.on_client_changed, this);
       this.hide_all_service_info = bind(this.hide_all_service_info, this);
       this.get_service = bind(this.get_service, this);
@@ -37,6 +38,7 @@
       this.set_template = bind(this.set_template, this);
       this.set_sampletype = bind(this.set_sampletype, this);
       this.set_sample = bind(this.set_sample, this);
+      this.set_contact = bind(this.set_contact, this);
       this.set_client = bind(this.set_client, this);
       this.set_reference_field = bind(this.set_reference_field, this);
       this.set_reference_field_query = bind(this.set_reference_field_query, this);
@@ -88,6 +90,7 @@
       $("tr[fieldname=InvoiceExclude] input[type='checkbox']").on("click", this.recalculate_records);
       $("tr[fieldname=Analyses] input[type='checkbox']").on("click", this.on_analysis_checkbox_click);
       $("tr[fieldname=Client] input[type='text']").on("selected change", this.on_client_changed);
+      $("tr[fieldname=Contact] input[type='text']").on("selected change", this.on_contact_changed);
       $("tr[fieldname=ReportDryMatter] input[type='checkbox']").on("click", this.on_reportdrymatter_click);
       $("input.min").on("change", this.on_analysis_specification_changed);
       $("input.max").on("change", this.on_analysis_specification_changed);
@@ -217,6 +220,9 @@
       return $.each(records, function(arnum, record) {
         $.each(record.client_metadata, function(uid, client) {
           return me.set_client(arnum, client);
+        });
+        $.each(record.contact_metadata, function(uid, contact) {
+          return me.set_contact(arnum, contact);
         });
         $.each(record.service_metadata, function(uid, metadata) {
           var lock;
@@ -480,6 +486,22 @@
       return this.set_reference_field_query(field, query);
     };
 
+    AnalysisRequestAdd.prototype.set_contact = function(arnum, contact) {
+
+      /*
+       * Set CC Contacts
+       */
+      var field, me;
+      me = this;
+      field = $("#CCContact-" + arnum);
+      return $.each(contact.cccontacts, function(index, cccontact) {
+        var title, uid;
+        uid = cccontact.uid;
+        title = cccontact.title;
+        return me.set_reference_field(field, uid, title);
+      });
+    };
+
     AnalysisRequestAdd.prototype.set_sample = function(arnum, sample) {
 
       /*
@@ -731,6 +753,27 @@
       arnum = $el.closest("[arnum]").attr("arnum");
       console.debug("°°° on_client_changed: arnum=" + arnum + " °°°");
       field_ids = ["Contact", "CCContact", "InvoiceContact", "SamplePoint", "Template", "Profiles", "Specification"];
+      $.each(field_ids, function(index, id) {
+        var field;
+        field = me.get_field_by_id(id, arnum);
+        return me.flush_reference_field(field);
+      });
+      return $(me).trigger("form:changed");
+    };
+
+    AnalysisRequestAdd.prototype.on_contact_changed = function(event) {
+
+      /*
+       * Eventhandler when the contact changed
+       */
+      var $el, arnum, el, field_ids, me, uid;
+      me = this;
+      el = event.currentTarget;
+      $el = $(el);
+      uid = $el.attr("uid");
+      arnum = $el.closest("[arnum]").attr("arnum");
+      console.debug("°°° on_contact_changed: arnum=" + arnum + " °°°");
+      field_ids = ["CCContact"];
       $.each(field_ids, function(index, id) {
         var field;
         field = me.get_field_by_id(id, arnum);

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -67,6 +67,8 @@ class window.AnalysisRequestAdd
     $("tr[fieldname=Analyses] input[type='checkbox']").on "click", @on_analysis_checkbox_click
     # Client changed
     $("tr[fieldname=Client] input[type='text']").on "selected change", @on_client_changed
+    # Contact changed
+    $("tr[fieldname=Contact] input[type='text']").on "selected change", @on_contact_changed
     # ReportDryMatter Checkbox clicked
     $("tr[fieldname=ReportDryMatter] input[type='checkbox']").on "click", @on_reportdrymatter_click
     # Analysis Specification changed
@@ -216,6 +218,10 @@ class window.AnalysisRequestAdd
       # set client
       $.each record.client_metadata, (uid, client) ->
         me.set_client arnum, client
+
+      # set contact
+      $.each record.contact_metadata, (uid, contact) ->
+        me.set_contact arnum, contact
 
       # set services
       $.each record.service_metadata, (uid, metadata) ->
@@ -515,6 +521,20 @@ class window.AnalysisRequestAdd
     field = $("#Sample-#{arnum}")
     query = client.filter_queries.sample
     @set_reference_field_query field, query
+
+
+  set_contact: (arnum, contact) =>
+    ###
+     * Set CC Contacts
+    ###
+    me = this
+
+    field = $("#CCContact-#{arnum}")
+
+    $.each contact.cccontacts, (index, cccontact) ->
+      uid = cccontact.uid
+      title = cccontact.title
+      me.set_reference_field field, uid, title
 
 
   set_sample: (arnum, sample) =>
@@ -823,6 +843,31 @@ class window.AnalysisRequestAdd
       "Template"
       "Profiles"
       "Specification"
+    ]
+    $.each field_ids, (index, id) ->
+      field = me.get_field_by_id id, arnum
+      me.flush_reference_field field
+
+    # trigger form:changed event
+    $(me).trigger "form:changed"
+
+
+  on_contact_changed: (event) =>
+    ###
+     * Eventhandler when the contact changed
+    ###
+
+    me = this
+    el = event.currentTarget
+    $el = $(el)
+    uid = $el.attr "uid"
+    arnum = $el.closest("[arnum]").attr "arnum"
+
+    console.debug "°°° on_contact_changed: arnum=#{arnum} °°°"
+
+    # Flush client depending fields
+    field_ids = [
+      "CCContact"
     ]
     $.each field_ids, (index, id) ->
       field = me.get_field_by_id id, arnum

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -531,10 +531,9 @@ class window.AnalysisRequestAdd
 
     field = $("#CCContact-#{arnum}")
 
-    $.each contact.cccontacts, (index, cccontact) ->
-      uid = cccontact.uid
-      title = cccontact.title
-      me.set_reference_field field, uid, title
+    $.each contact.cccontacts, (uid, cccontact) ->
+      fullname = cccontact.fullname
+      me.set_reference_field field, uid, fullname
 
 
   set_sample: (arnum, sample) =>

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1341,6 +1341,9 @@ class window.AnalysisRequestAdd
           # single reference field
           me.set_reference_field _field, uid, value
 
+        # notify that the field changed
+        $(_field).trigger "change"
+
       # trigger form:changed event
       $(me).trigger "form:changed"
       return


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/491

## Current behavior before PR

CCContacts are not automatically selected on Contact change

## Desired behavior after PR is merged

CCContacts selected automatically on Contact change

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
