### PR TITLE
Rejection widget doesn't appear

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Changelog
 
 **Fixed**
 
+- #494 Rejection reasons widget does not appear on rejection
 - #492 Fix AR Add Form: CC Contacts not set on Contact Change
 - #489 Worksheet Templates selection list is empty in Worksheets view
 - #490 Fix AR Add Form: No specifications found if a sample type was set

--- a/bika/lims/browser/js/bika.lims.rejection.js
+++ b/bika/lims/browser/js/bika.lims.rejection.js
@@ -49,7 +49,16 @@
              var td = $('#archetypes-fieldname-RejectionWidget').parent('td');
              var label = "<div class='semioverlay-head'>"+$(td).prev('td').html().trim()+"</div>";
              // Creating the div element
-             $('#content').prepend("<div id='semioverlay'><div class='semioverlay-back'></div><div class='semioverlay-panel'><div class='semioverlay-content'></div><div class='semioverlay-buttons'><input type='button' name='semioverlay.reject' value='reject'/><input type='button' name='semioverlay.cancel' value='cancel'/></div></div></div>");
+             $('#content').prepend(
+                "<div id='semioverlay' style='display:none'>" +
+                " <div class='semioverlay-back'> </div>" +
+                " <div class='semioverlay-panel'>" +
+                " <div class='semioverlay-content'></div>" +
+                " <div class='semioverlay-buttons'>" +
+                " <input type='button'" +
+                " name='semioverlay.reject' value='reject'/>" +
+                " <input type='button' name='semioverlay.cancel'" +
+                " value='cancel'/></div></div></div>");
              // Moving the widget there
              $('#archetypes-fieldname-RejectionWidget').detach().prependTo('#semioverlay .semioverlay-content');
              // hidding the widget's td and moving the label
@@ -73,7 +82,6 @@
                  $('div#semioverlay .semioverlay-panel').fadeOut();
                  reject_ar_sample();
              });
-             $('div#semioverlay .semioverlay-panel').hide();
          }
      }
 

--- a/bika/lims/browser/js/bika.lims.rejection.js
+++ b/bika/lims/browser/js/bika.lims.rejection.js
@@ -5,16 +5,6 @@
 
      var that = this;
      that.load = function() {
-         // I don't know why samples don't have the reject state button, so I'll
-         // have to insert a handmade one.
-         if ($('body').hasClass('portaltype-sample') &&
-            $('#plone-contentmenu-workflow .state-reject').length < 1) {
-                var url = window.location.href.replace('/base_view','');
-                var autentification = $('input[name="_authenticator"]').val();
-                // we have to insert the state button
-                var dom_e = '<li><a id="workflow-transition-reject" class="" title="" href="' + url + '/doActionForSample?workflow_action=reject&_authenticator=' + autentification + '">Reject</li>"';
-                $(dom_e).prependTo($('#plone-contentmenu-workflow dd.actionMenuContent ul')[0]);
-         }
         // If rejection workflow is disabled, hide the state link
         var request_data = {
             catalog_name: "portal_catalog",


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/senaite/bika.lims/issues/493

Apart from the issue, this PR also deletes redundant code. Since workflow system has been improved, not there is no need to create the option "reject" by JS in sample view.


## Current behavior before PR

After clicking on the "reject" transition button, the overlay is loaded but there is no visible widget inside.

## Desired behavior after PR is merged

The overlay appears with the widget inside.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
