### PR TITLE
Inconsistences when applying Worksheet Templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Changelog
 
 **Fixed**
 
+- #499 Wrong slots when adding analyses manually in Worksheet with a WST assigned
+- #499 When a Worksheet Template is used, slot positions are not applied correctly
+- #499 Applying a WS template which references a Duplicate raises an Error
 
 **Security**
 

--- a/bika/lims/browser/worksheet/views/add_duplicate.py
+++ b/bika/lims/browser/worksheet/views/add_duplicate.py
@@ -47,9 +47,8 @@ class AddDuplicateView(BrowserView):
             ar_uid = self.request.get('ar_uid', '')
             src_slot = [slot['position'] for slot in self.context.getLayout() if
                         slot['container_uid'] == ar_uid and slot['type'] == 'a'][0]
-            position = self.request.get('position', '')
             self.request['context_uid'] = self.context.UID()
-            self.context.addDuplicateAnalyses(src_slot, position)
+            self.context.addDuplicateAnalyses(src_slot)
             self.request.response.redirect(self.context.absolute_url() + "/manage_results")
         else:
             self.ARs = AnalysisRequestsView(self.context, self.request)

--- a/bika/lims/browser/worksheet/views/add_worksheet.py
+++ b/bika/lims/browser/worksheet/views/add_worksheet.py
@@ -59,7 +59,6 @@ class AddWorksheetView(BrowserView):
             return
 
         wst = rc.lookupObject(template)
-        ws.setWorksheetTemplate(wst)
         ws.applyWorksheetTemplate(wst)
 
         if ws.getLayout():

--- a/bika/lims/content/duplicateanalysis.py
+++ b/bika/lims/content/duplicateanalysis.py
@@ -116,6 +116,8 @@ class DuplicateAnalysis(AbstractRoutineAnalysis):
     @security.public
     def setAnalysis(self, analysis):
         # Copy all the values from the schema
+        if not analysis:
+            return
         discard = ['id', ]
         keys = analysis.Schema().keys()
         for key in keys:

--- a/bika/lims/content/reflexrule.py
+++ b/bika/lims/content/reflexrule.py
@@ -391,7 +391,7 @@ def _createWorksheet(base, worksheettemplate, analyst):
         Analyst=analyst,
         )
     if worksheettemplate:
-        ws.setWorksheetTemplate(worksheettemplate)
+        ws.applyWorksheetTemplate(worksheettemplate)
     return ws
 
 

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -535,7 +535,6 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         if not worksheet_template or type not in ['a', 'b', 'c', 'd']:
             return list()
 
-        # Get the list of slots occupied by the type in this worksheet
         ws_slots = self.get_slot_positions(type)
         layout = worksheet_template.getLayout()
         slots = list()
@@ -819,7 +818,6 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             only be applied to those analyses for which the instrument
             is allowed, the same happens with methods.
         """
-        import pdb;pdb.set_trace()
         if not wst:
             return
 

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -262,7 +262,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
     def addReferences(self, position, reference, service_uids):
         """ Add reference analyses to reference, and add to worksheet layout
         """
-        self._add_reference_analysis(reference, service_uids, position)
+        self.addReferenceAnalyses(reference, service_uids, position)
 
     def addReferenceAnalyses(self, reference, service_uids, dest_slot=None):
         """
@@ -360,6 +360,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         # Add the duplicate in the worksheet
         self.setAnalyses(self.getAnalyses() + [ref_analysis, ])
         doActionFor(ref_analysis, 'assign')
+        return ref_analysis
 
     def nextReferenceAnalysesGroupID(self, reference):
         """ Returns the next ReferenceAnalysesGroupID for the given reference
@@ -482,15 +483,15 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
 
         is_duplicate = IDuplicateAnalysis.providedBy(analysis)
         is_reference = IReferenceAnalysis.providedBy(analysis)
-        if not is_duplicate or not is_reference:
-            logger.warning('Cannot set a reference analysis group id to an '
-                           'analysis that is neither a reference analysis nor '
-                           'a duplicate: {}'.format(analysis.getId()))
+        if not is_duplicate and not is_reference:
+            logger.warn('Cannot set a reference analysis group id to an '
+                        'analysis that is neither a reference analysis nor '
+                        'a duplicate: {}'.format(analysis.getId()))
             return
 
         sample = analysis.getSample()
         refgid = self.nextReferenceAnalysesGroupID(sample)
-        analysis.setReferenceAnalysisGroupID(refgid)
+        analysis.setReferenceAnalysesGroupID(refgid)
         analysis.reindexObject(idxs=["getReferenceAnalysesGroupID"])
 
     def _get_suitable_slot_for_duplicate(self, src_slot):

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -368,14 +368,20 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             for the specified reference sample and increments in one unit the
             suffix.
         """
+        prefix = reference.id+"-"
+        if not IReferenceSample.providedBy(reference):
+            # Not a ReferenceSample, so this is a duplicate
+            prefix = reference.id+"-D"
         bac = getToolByName(reference, 'bika_analysis_catalog')
         ids = bac.Indexes['getReferenceAnalysesGroupID'].uniqueValues()
-        prefix = reference.id+"-"
         rr = re.compile("^"+prefix+"[\d+]+$")
         ids = [int(i.split(prefix)[1]) for i in ids if i and rr.match(i)]
         ids.sort()
         _id = ids[-1] if ids else 0
         suffix = str(_id+1).zfill(int(3))
+        if not IReferenceSample.providedBy(reference):
+            # Not a ReferenceSample, so this is a duplicate
+            suffix = str(_id+1).zfill(2)
         return '%s%s' % (prefix, suffix)
 
     security.declareProtected(EditWorksheet, 'addDuplicateAnalyses')

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -769,12 +769,17 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         bac = api.get_tool("bika_analysis_catalog")
         services = wst.getService()
         wst_service_uids = [s.UID() for s in services]
-        analyses = bac(portal_type='Analysis',
-                       getServiceUID=wst_service_uids,
-                       review_state='sample_received',
-                       worksheetanalysis_review_state='unassigned',
-                       cancellation_state='active',
-                       sort_on='getPrioritySortkey')
+
+        query = {
+            "portal_type": "Analysis",
+            "getServiceUID": wst_service_uids,
+            "review_state": "sample_received",
+            "worksheetanalysis_review_state": "unassigned",
+            "cancellation_state": "active",
+            "sort_on": "getPrioritySortkey"
+        }
+
+        analyses = bac(query)
 
         # No analyses, nothing to do
         if not analyses:
@@ -801,8 +806,8 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         ar_slots = dict()
         ar_fixed_slots = dict()
         for brain in analyses:
-            arid = brain.getRequestID
             obj = api.get_object(brain)
+            arid = obj.getRequestID()
             if instrument and not obj.isInstrumentAllowed(instrument):
                 # Exclude those analyses for which the worksheet's template
                 # instrument is not allowed

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -312,10 +312,9 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
                                                         slot_to,
                                                         refgid)
 
-            # All ref analyses from the same slot must have the same group id
-            refgid = ref_analysis.getReferenceAnalysesGroupID()
-
             if ref_analysis:
+                # All ref analyses from the same slot must have the same group id
+                refgid = ref_analysis.getReferenceAnalysesGroupID()
                 ref_analyses.append(ref_analysis)
         return ref_analyses
 
@@ -436,10 +435,9 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             processed.append(analysis_uid)
             duplicate = self._add_duplicate(analysis, slot_to, refgid)
 
-            # All duplicates from the same slot must have the same group id
-            refgid = duplicate.getReferenceAnalysesGroupID()
-
             if duplicate:
+                # All duplicates from the same slot must have the same group id
+                refgid = duplicate.getReferenceAnalysesGroupID()
                 duplicates.append(duplicate)
         return duplicates
 

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -125,6 +125,14 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
     def Title(self):
         return safe_unicode(self.getId()).encode('utf-8')
 
+    def setLayout(self, value):
+        """
+        Sets the worksheet layout, keeping it sorted by position
+        :param value: the layout to set
+        """
+        new_layout = sorted(value, key=lambda k: k['position'])
+        self.getField('Layout').set(self, new_layout)
+
     security.declareProtected(EditWorksheet, 'addAnalysis')
     def addAnalysis(self, analysis, position=None):
         """- add the analysis to self.Analyses().

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -442,6 +442,44 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             self.setAnalyses(self.getAnalyses() + [duplicate, ])
             doActionFor(duplicate, 'assign')
 
+    def get_analyses_at(self, slot):
+        """
+        Returns the list of analyses assigned to the slot passed in, sorted by
+        the positions they have within the slot.
+        :param slot: the slot where the analyses are located
+        :type slot: int
+        :return: a list of analyses
+        """
+        analyses = []
+        uc = api.get_tool('uid_catalog')
+        layout = self.getLayout()
+        for pos in layout:
+            layout_slot = int(pos['position'])
+            uid = pos['analysis_uid']
+            if layout_slot != slot or not uid:
+                continue
+            brain = uc(UID=uid)
+            analyses.append(api.get_object(brain[0]))
+        return analyses
+
+    def get_container_at(self, slot):
+        """
+        Returns the container object assigned to the slot passed in
+        :param slot: the slot where the analyses are located
+        :type slot: int
+        :return: the container (analysis request, reference sample, etc.)
+        """
+        uc = api.get_tool('uid_catalog')
+        layout = self.getLayout()
+        for pos in layout:
+            layout_slot = int(pos['position'])
+            uid = pos['container_uid']
+            if layout_slot != slot or not uid:
+                continue
+            brain = uc(UID=uid)
+            return api.get_object(brain[0])
+        return None
+
     def get_slot_positions(self, type='a'):
         """
         Returns a list with the slots occupied for the type passed in.
@@ -458,7 +496,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             if type != 'all' and slot['type'] != type:
                 continue
             slots.append(int(slot['position']))
-        return slots
+        return sorted(set(slots))
 
     def get_slot_position(self, container, type='a'):
         """

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -4,12 +4,8 @@
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 import re
-import sys
-import collections
 
 from AccessControl import ClassSecurityInfo
-from operator import itemgetter, attrgetter
-
 from DateTime import DateTime
 from Products.ATContentTypes.lib.historyaware import HistoryAwareMixin
 from Products.ATExtensions.ateapi import RecordsField
@@ -18,11 +14,11 @@ from Products.Archetypes.public import *
 from Products.Archetypes.references import HoldingReference
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import _createObjectByType, safe_unicode
+from bika.lims import api
 from bika.lims import bikaMessageFactory as _
 from bika.lims import deprecated
 from bika.lims import logger
 from bika.lims.browser.fields import UIDReferenceField
-from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.config import *
 from bika.lims.config import PROJECTNAME
 from bika.lims.content.bikaschema import BikaSchema
@@ -40,7 +36,6 @@ from bika.lims.workflow import getCurrentState
 from bika.lims.workflow import skip
 from bika.lims.workflow.worksheet import events
 from bika.lims.workflow.worksheet import guards
-from bika.lims import api
 from plone.api.user import has_permission
 from zope.interface import implements
 
@@ -451,8 +446,8 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         passed in is not an IRoutineAnalysis, is retracted or has dependent
         services, returns None.If no reference analyses group id (refgid) is
         set, the value will be generated automatically.
-        :param analysis: analysis to create a duplicate from
-        :param dest_slot: slot where the duplicate analysis must be stored
+        :param src_analysis: analysis to create a duplicate from
+        :param destination_slot: slot where duplicate analysis must be stored
         :param refgid: the reference analysis group id to be set
         :return: the duplicate analysis or None
         """
@@ -1489,9 +1484,9 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             if review_state in ['published', 'verified', 'retracted']:
                 old_ws_analyses.append(analysis.UID())
                 old_layout.append({'position': position,
-                                   'type':'a',
-                                   'analysis_uid':analysis.UID(),
-                                   'container_uid':analysis.aq_parent.UID()})
+                                   'type': 'a',
+                                   'analysis_uid': analysis.UID(),
+                                   'container_uid': analysis.aq_parent.UID()})
                 continue
             # Normal analyses:
             # - Create matching RejectAnalysis inside old WS
@@ -1513,14 +1508,14 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
                 position = analysis_positions[analysis.UID()]
                 old_ws_analyses.append(reject.UID())
                 old_layout.append({'position': position,
-                                   'type':'r',
-                                   'analysis_uid':reject.UID(),
-                                   'container_uid':self.UID()})
+                                   'type': 'r',
+                                   'analysis_uid': reject.UID(),
+                                   'container_uid': self.UID()})
                 new_ws_analyses.append(analysis.UID())
                 new_layout.append({'position': position,
                                    'type':'a',
-                                   'analysis_uid':analysis.UID(),
-                                   'container_uid':analysis.aq_parent.UID()})
+                                   'analysis_uid': analysis.UID(),
+                                   'container_uid': analysis.aq_parent.UID()})
             # Reference analyses
             # - Create a new reference analysis in the new worksheet
             # - Transition the original analysis to 'rejected' state
@@ -1533,14 +1528,14 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
                 position = analysis_positions[analysis.UID()]
                 old_ws_analyses.append(analysis.UID())
                 old_layout.append({'position': position,
-                                   'type':reference_type,
-                                   'analysis_uid':analysis.UID(),
-                                   'container_uid':reference.UID()})
+                                   'type': reference_type,
+                                   'analysis_uid': analysis.UID(),
+                                   'container_uid': reference.UID()})
                 new_ws_analyses.append(new_analysis_uid)
                 new_layout.append({'position': position,
-                                   'type':reference_type,
-                                   'analysis_uid':new_analysis_uid,
-                                   'container_uid':reference.UID()})
+                                   'type': reference_type,
+                                   'analysis_uid': new_analysis_uid,
+                                   'container_uid': reference.UID()})
                 workflow.doActionFor(analysis, 'reject')
                 new_reference = reference.uid_catalog(UID=new_analysis_uid)[0].getObject()
                 workflow.doActionFor(new_reference, 'assign')
@@ -1561,14 +1556,14 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
                 position = analysis_positions[analysis.UID()]
                 old_ws_analyses.append(analysis.UID())
                 old_layout.append({'position': position,
-                                   'type':'d',
-                                   'analysis_uid':analysis.UID(),
-                                   'container_uid':self.UID()})
+                                   'type': 'd',
+                                   'analysis_uid': analysis.UID(),
+                                   'container_uid': self.UID()})
                 new_ws_analyses.append(new_duplicate.UID())
                 new_layout.append({'position': position,
                                    'type':'d',
-                                   'analysis_uid':new_duplicate.UID(),
-                                   'container_uid':new_ws.UID()})
+                                   'analysis_uid': new_duplicate.UID(),
+                                   'container_uid': new_ws.UID()})
                 workflow.doActionFor(analysis, 'reject')
                 analysis.reindexObject()
 

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -671,18 +671,22 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         be generated for that given slot.
         :param wst: worksheet template used as the layout
         """
-        ws_slots = self.get_slot_positions('a')
-        ws_dup_slots = self.get_slot_positions('d')
+        occupied_slots = self.get_slot_positions(type='all')
         wst_layout = wst.getLayout()
         for row in wst_layout:
             if row['type'] != 'd':
                 continue
-            dest_pos = int(row['pos'])
-            if dest_pos in ws_dup_slots:
-                continue
+
             src_pos = int(row['dup'])
-            if src_pos not in ws_slots:
+            if src_pos not in occupied_slots:
+                # There is no source analysis available
                 continue
+
+            dest_pos = int(row['pos'])
+            if dest_pos in occupied_slots:
+                # This slot is already occupied
+                continue
+
             self.addDuplicateAnalyses(src_pos, dest_pos)
 
     def _resolve_reference_sample(self, reference_samples=None,

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -782,8 +782,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
         best_sample = None
         best_supported = None
         for sample in reference_samples:
-            specs = sample.getResultsRangeDict()
-            specs_uids = specs.keys()
+            specs_uids = sample.getResultsRangeDict().keys()
             supported = [uid for uid in specs_uids if uid in service_uids]
             matches = len(supported)
             overlays = len(service_uids) - matches
@@ -845,7 +844,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
                 obj = api.get_object(sample)
                 if (type == 'b' and obj.getBlank()) or \
                         (type == 'c' and not obj.getBlank()):
-                    candidates.append(sample)
+                    candidates.append(obj)
 
             sample, uids = self._resolve_reference_sample(candidates, services)
             if not sample:
@@ -876,7 +875,7 @@ class Worksheet(BaseFolder, HistoryAwareMixin):
             slot = reference['slot']
             sample = reference['sample']
             services = reference['supported_services']
-            self.addReference(slot, sample, services)
+            self.addReferences(slot, sample, services)
 
     def applyWorksheetTemplate(self, wst):
         """ Add analyses to worksheet according to wst's layout.

--- a/bika/lims/content/worksheet.py
+++ b/bika/lims/content/worksheet.py
@@ -4,6 +4,9 @@
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 import re
+import sys
+import collections
+from operator import itemgetter, attrgetter
 
 from AccessControl import ClassSecurityInfo
 from DateTime import DateTime

--- a/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
+++ b/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
@@ -202,6 +202,10 @@ slots reserved for blank and controls are not occupied:
     >>> worksheet.get_slot_positions(type='b')
     []
 
+
+Remove analyses and Apply Worksheet Template again
+==================================================
+
 Remove analyses located at position 2:
     >>> to_del = worksheet.get_analyses_at(2)
     >>> worksheet.removeAnalysis(to_del[0])
@@ -232,3 +236,75 @@ And each slot contains the additional analysis Au:
 
     >>> [an.getKeyword() for an in slot1_analyses]
     ['Cu', 'Fe', 'Au']
+
+As well as in duplicate analyses:
+    >>> dup1 = worksheet.get_analyses_at(3)
+    >>> len(dup1) == 3
+    True
+
+    >>> slot3_analyses = worksheet.get_analyses_at(3)
+    >>> [an.getKeyword() for an in slot3_analyses]
+    ['Cu', 'Fe', 'Au']
+
+
+Remove a duplicate and add it manually
+======================================
+
+Remove all duplicate analyses from slot 5:
+    >>> dup5 = worksheet.get_analyses_at(5)
+    >>> len(dup5) == 3
+    True
+
+    >>> worksheet.removeAnalysis(dup5[0])
+    >>> worksheet.removeAnalysis(dup5[1])
+    >>> worksheet.removeAnalysis(dup5[2])
+    >>> dup5 = worksheet.get_analyses_at(5)
+    >>> len(dup5) == 0
+    True
+
+Add duplicates using the same source routine analysis, located at slot 4, but
+manually instead of applying the Worksheet Template:
+    >>> dups = worksheet.addDuplicateAnalyses(4)
+
+Three duplicate has been added to the worksheet:
+    >>> [dup.getKeyword() for dup in dups]
+    ['Cu', 'Fe', 'Au']
+
+And these duplicates have been added in the slot number 5, cause this slot is
+where this duplicate fits better in accordance with the layout defined in the
+worksheet template associated to this worksheet template:
+    >>> dup5 = worksheet.get_analyses_at(5)
+    >>> [dup.getKeyword() for dup in dup5]
+    ['Cu', 'Fe', 'Au']
+
+    >>> dups_uids = [dup.UID() for dup in dups]
+    >>> dup5_uids = [dup.UID() for dup in dup5]
+    >>> [dup for dup in dup5_uids if dup not in dups_uids]
+    []
+
+But if we remove only one duplicate analysis from slot number 5:
+
+    >>> worksheet.removeAnalysis(dup5[0])
+    >>> dup5 = worksheet.get_analyses_at(5)
+    >>> [dup.getKeyword() for dup in dup5]
+    ['Fe', 'Au']
+
+And we manually add duplicates for analysis in position 4, a new slot will be
+added at the end of the worksheet (slot number 8), cause the slot number 5 is
+already occupied and slots 6 and 7, altough empty, are reserved for blank and
+control:
+    >>> worksheet.get_analyses_at(8)
+    []
+
+    >>> dups = worksheet.addDuplicateAnalyses(4)
+    >>> [dup.getKeyword() for dup in dups]
+    ['Cu', 'Fe', 'Au']
+
+    >>> dup8 = worksheet.get_analyses_at(8)
+    >>> [dup.getKeyword() for dup in dup8]
+    ['Cu', 'Fe', 'Au']
+
+    >>> dups_uids = [dup.UID() for dup in dups]
+    >>> dup8_uids = [dup.UID() for dup in dup8]
+    >>> [dup for dup in dup8_uids if dup not in dups_uids]
+    []

--- a/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
+++ b/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
@@ -232,7 +232,7 @@ Only slots 1, 4 are filled with routine analyses now:
     >>> worksheet.get_slot_positions(type='a')
     [1, 4]
 
-Modify the Worksheet Template to allow Au analysis and apply the template to the
+Modify the Worksheet Template to allow `Au` analysis and apply the template to the
 same Worksheet again:
 
     >>> service_uids = [Cu.UID(), Fe.UID(), Au.UID()]
@@ -244,7 +244,7 @@ Now, slot 2 is filled again:
     >>> worksheet.get_slot_positions(type='a')
     [1, 2, 4]
 
-And each slot contains the additional analysis Au:
+And each slot contains the additional analysis `Au`:
 
     >>> slot1_analyses = worksheet.get_analyses_at(1)
     >>> len(slot1_analyses) == 3

--- a/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
+++ b/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
@@ -99,7 +99,7 @@ Worksheet Template creation
 ---------------------------
 
 Create a Worksheet Template, but for `Cu` and `Fe` analyses, with the following
-layout with 5 slots:
+layout with 7 slots:
 
   * Routine analyses in slots 1, 2, 4
   * Duplicate analysis from slot 1 in slot 3
@@ -184,6 +184,10 @@ each time we add an analysis, it will be added into it's corresponding slot:
 
     >>> slot1_analyses = worksheet.get_analyses_at(1)
     >>> an_ar = list(set([an.getRequestUID() for an in slot1_analyses]))
+
+    >>> len(an_ar) == 1
+    True
+
     >>> an_ar[0] == ar0.UID()
     True
 

--- a/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
+++ b/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
@@ -8,16 +8,17 @@ aggregate related tests from different Analysis Requests to be processed in a
 single run.
 
 Although worksheets can be created manually by the labmanager each time is
-required, a better approach is to create them by using Worksheet Templates. In
-a Worksheet Template, the labman defines the layout, the number of slots and
-the type of analyses (reference or routine) to be placed in each slot, as well
-as the Method and Instrument to be assigned. Thus, Worksheet Templates are used
-for the semi-automated creation of Worksheets.
+required, a better approach is to create them by using Worksheet Templates. In a
+Worksheet Template, the labman defines the layout, the number of slots and the
+type of analyses (reference or routine) to be placed in each slot, as well as
+the Method and Instrument to be assigned. Thus, Worksheet Templates are used for
+the semi-automated creation of Worksheets.
 
 This doctest will validate the consistency between the Worksheet and the
 Worksheet Template used for its creation. It will also test the correctness of
 the worksheet when applying a Worksheet Template in a manually created
 Worksheet.
+
 
 Test Setup
 ==========
@@ -74,7 +75,8 @@ We need to create some basic objects for the test:
     >>> Fe = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Iron", Keyword="Fe", Price="10", Category=category.UID())
     >>> Au = api.create(bikasetup.bika_analysisservices, "AnalysisService", title="Gold", Keyword="Au", Price="20", Category=category.UID())
 
-Create some Analysis Requests so we can use them as sources for Worksheet cration
+Create some Analysis Requests, so we can use them as sources for Worksheet cration:
+
     >>> values = {
     ...     'Client': client.UID(),
     ...     'Contact': contact.UID(),
@@ -96,43 +98,46 @@ Create some Analysis Requests so we can use them as sources for Worksheet cratio
 Worksheet Template creation
 ---------------------------
 
-Create a Worksheet Template, but will only accept Cu and Fe analyses, with the
-following layout, made of 5 slots:
+Create a Worksheet Template, but for `Cu` and `Fe` analyses, with the following
+layout with 5 slots:
 
-* Routine analyses in slots 1, 2, 4
-* Duplicate analysis from slot 1 in slot 3
-* Duplicate analysis from slot 4 in slot 5
-* Control analysis in slot 6
-* Blank analysis in slot 7
+  * Routine analyses in slots 1, 2, 4
+  * Duplicate analysis from slot 1 in slot 3
+  * Duplicate analysis from slot 4 in slot 5
+  * Control analysis in slot 6
+  * Blank analysis in slot 7
+
     >>> service_uids = [Cu.UID(), Fe.UID()]
-    >>> layout = [{'pos': '1', 'type': 'a',
-    ...            'blank_ref': '',
-    ...            'control_ref': '',
-    ...            'dup': ''},
-    ...           {'pos': '2', 'type': 'a',
-    ...            'blank_ref': '',
-    ...            'control_ref': '',
-    ...            'dup': ''},
-    ...           {'pos': '3', 'type': 'd',
-    ...            'blank_ref': '',
-    ...            'control_ref': '',
-    ...            'dup': '1'},
-    ...           {'pos': '4', 'type': 'a',
-    ...            'blank_ref': '',
-    ...            'control_ref': '',
-    ...            'dup': ''},
-    ...           {'pos': '5', 'type': 'd',
-    ...            'blank_ref': '',
-    ...            'control_ref': '',
-    ...            'dup': '4'},
-    ...           {'pos': '6', 'type': 'c',
-    ...            'blank_ref': '',
-    ...            'control_ref': 'jajsjas',
-    ...            'dup': ''},
-    ...           {'pos': '7', 'type': 'b',
-    ...            'blank_ref': 'asasasa',
-    ...            'control_ref': '',
-    ...            'dup': ''},]
+    >>> layout = [
+    ...     {'pos': '1', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ...     {'pos': '2', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ...     {'pos': '3', 'type': 'd',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': '1'},
+    ...     {'pos': '4', 'type': 'a',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ...     {'pos': '5', 'type': 'd',
+    ...      'blank_ref': '',
+    ...      'control_ref': '',
+    ...      'dup': '4'},
+    ...     {'pos': '6', 'type': 'c',
+    ...      'blank_ref': '',
+    ...      'control_ref': 'jajsjas',
+    ...      'dup': ''},
+    ...     {'pos': '7', 'type': 'b',
+    ...      'blank_ref': 'asasasa',
+    ...      'control_ref': '',
+    ...      'dup': ''},
+    ... ]
     >>> template = api.create(bikasetup.bika_worksheettemplates, "WorksheetTemplate", title="WS Template Test", Layout=layout, Service=service_uids)
 
 
@@ -140,16 +145,19 @@ Apply Worksheet Template to a Worksheet
 =======================================
 
 Create a new Worksheet by using this worksheet template:
+
     >>> worksheet = api.create(portal.worksheets, "Worksheet")
     >>> worksheet.applyWorksheetTemplate(template)
 
 Since we haven't received any analysis requests, this worksheet remains empty:
+
     >>> worksheet.getAnalyses()
     []
     >>> worksheet.getLayout()
     []
 
 Receive the Analysis Requests and apply again the Worksheet Template:
+
     >>> performed = doActionFor(ar0, 'receive')
     >>> performed = doActionFor(ar1, 'receive')
     >>> performed = doActionFor(ar2, 'receive')
@@ -163,11 +171,13 @@ Receive the Analysis Requests and apply again the Worksheet Template:
     >>> worksheet.applyWorksheetTemplate(template)
 
 Slots 1, 2 and 4 are filled with routine analyses:
+
     >>> worksheet.get_slot_positions(type='a')
     [1, 2, 4]
 
 Each slot occupied by routine analyses is assigned to an Analysis Request, so
 each time we add an analysis, it will be added into it's corresponding slot:
+
     >>> container = worksheet.get_container_at(1)
     >>> container.UID() == ar0.UID()
     True
@@ -181,6 +191,7 @@ each time we add an analysis, it will be added into it's corresponding slot:
     ['Cu', 'Fe']
 
 Slots 3 and 5 are filled with duplicate analyses:
+
     >>> worksheet.get_slot_positions(type='d')
     [3, 5]
 
@@ -193,12 +204,14 @@ Slots 3 and 5 are filled with duplicate analyses:
 
 The first duplicate analysis located at slot 3 is a duplicate of the first
 analysis from slot 1:
+
     >>> dup_an = dup1[0].getAnalysis()
     >>> slot1_analyses[0].UID() == dup_an.UID()
     True
 
 But since we haven't created any reference analysis (neither blank or control),
 slots reserved for blank and controls are not occupied:
+
     >>> worksheet.get_slot_positions(type='c')
     []
     >>> worksheet.get_slot_positions(type='b')
@@ -209,25 +222,30 @@ Remove analyses and Apply Worksheet Template again
 ==================================================
 
 Remove analyses located at position 2:
+
     >>> to_del = worksheet.get_analyses_at(2)
     >>> worksheet.removeAnalysis(to_del[0])
     >>> worksheet.removeAnalysis(to_del[1])
 
 Only slots 1, 4 are filled with routine analyses now:
+
     >>> worksheet.get_slot_positions(type='a')
     [1, 4]
 
-Modify the Worksheet Template to allow Au analysis and apply the template to
-the same Worksheet again:
+Modify the Worksheet Template to allow Au analysis and apply the template to the
+same Worksheet again:
+
     >>> service_uids = [Cu.UID(), Fe.UID(), Au.UID()]
     >>> template.setService(service_uids)
     >>> worksheet.applyWorksheetTemplate(template)
 
 Now, slot 2 is filled again:
+
     >>> worksheet.get_slot_positions(type='a')
     [1, 2, 4]
 
 And each slot contains the additional analysis Au:
+
     >>> slot1_analyses = worksheet.get_analyses_at(1)
     >>> len(slot1_analyses) == 3
     True
@@ -240,6 +258,7 @@ And each slot contains the additional analysis Au:
     ['Cu', 'Fe', 'Au']
 
 As well as in duplicate analyses:
+
     >>> dup1 = worksheet.get_analyses_at(3)
     >>> len(dup1) == 3
     True
@@ -253,6 +272,7 @@ Remove a duplicate and add it manually
 ======================================
 
 Remove all duplicate analyses from slot 5:
+
     >>> dup5 = worksheet.get_analyses_at(5)
     >>> len(dup5) == 3
     True
@@ -266,15 +286,18 @@ Remove all duplicate analyses from slot 5:
 
 Add duplicates using the same source routine analysis, located at slot 4, but
 manually instead of applying the Worksheet Template:
+
     >>> dups = worksheet.addDuplicateAnalyses(4)
 
 Three duplicate have been added to the worksheet:
+
     >>> [dup.getKeyword() for dup in dups]
     ['Cu', 'Fe', 'Au']
 
 And these duplicates have been added in the slot number 5, cause this slot is
 where this duplicate fits better in accordance with the layout defined in the
 worksheet template associated to this worksheet:
+
     >>> dup5 = worksheet.get_analyses_at(5)
     >>> [dup.getKeyword() for dup in dup5]
     ['Cu', 'Fe', 'Au']
@@ -295,6 +318,7 @@ And we manually add duplicates for analysis in position 4, a new slot will be
 added at the end of the worksheet (slot number 8), cause the slot number 5 is
 already occupied and slots 6 and 7, altough empty, are reserved for blank and
 control:
+
     >>> worksheet.get_analyses_at(8)
     []
 
@@ -316,18 +340,21 @@ Control and blanks with Worksheet Template
 ==========================================
 
 First, create a Reference Definition for blank:
+
     >>> blankdef = api.create(bikasetup.bika_referencedefinitions, "ReferenceDefinition", title="Blank definition", Blank=True)
     >>> blank_refs = [{'uid': Cu.UID(), 'result': '0', 'min': '0', 'max': '0', 'error': '0'},
     ...               {'uid': Fe.UID(), 'result': '0', 'min': '0', 'max': '0', 'error': '0'},]
     >>> blankdef.setReferenceResults(blank_refs)
 
 And for control:
+
     >>> controldef = api.create(bikasetup.bika_referencedefinitions, "ReferenceDefinition", title="Control definition")
     >>> control_refs = [{'uid': Cu.UID(), 'result': '10', 'min': '0.9', 'max': '10.1', 'error': '0.1'},
     ...                 {'uid': Fe.UID(), 'result': '10', 'min': '0.9', 'max': '10.1', 'error': '0.1'},]
     >>> controldef.setReferenceResults(control_refs)
 
 Then, we create the associated Reference Samples:
+
     >>> blank = api.create(supplier, "ReferenceSample", title="Blank",
     ...                    ReferenceDefinition=blankdef,
     ...                    Blank=True, ExpiryDate=date_future,
@@ -338,6 +365,7 @@ Then, we create the associated Reference Samples:
     ...                      ReferenceResults=control_refs)
 
 Apply the blank and control to the Worksheet Template layout:
+
     >>> layout = template.getLayout()
     >>> layout[5] = {'pos': '6', 'type': 'c',
     ...              'blank_ref': '',
@@ -350,10 +378,12 @@ Apply the blank and control to the Worksheet Template layout:
     >>> template.setLayout(layout)
 
 Apply the worksheet template again:
+
     >>> worksheet.applyWorksheetTemplate(template)
 
 Blank analyses at slot number 7, but note the reference definition is only for
-analyses 'Cu' and 'Fe':
+analyses `Cu` and `Fe`:
+
     >>> ans = worksheet.get_analyses_at(7)
     >>> [an.getKeyword() for an in ans]
     ['Cu', 'Fe']
@@ -361,6 +391,7 @@ analyses 'Cu' and 'Fe':
     ['b']
 
 Control analyses at slot number 6:
+
     >>> ans = worksheet.get_analyses_at(6)
     >>> [an.getKeyword() for an in ans]
     ['Cu', 'Fe']
@@ -372,6 +403,7 @@ Remove Reference Analyses and add them manually
 ===============================================
 
 Remove all controls from slot 6:
+
     >>> ans6 = worksheet.get_analyses_at(6)
     >>> len(ans6)
     2
@@ -382,6 +414,7 @@ Remove all controls from slot 6:
     []
 
 Add a reference analysis, but manually:
+
     >>> ref_ans = worksheet.addReferenceAnalyses(control, [Fe.UID(), Cu.UID()])
     >>> [ref.getKeyword() for ref in ref_ans]
     ['Cu', 'Fe']
@@ -389,6 +422,7 @@ Add a reference analysis, but manually:
 These reference analyses have been added in the slot number 6, cause this slot
 is where these reference analyses fit better in accordance with the layout
 defined in the worksheet template associated to this worksheet:
+
     >>> ref6 = worksheet.get_analyses_at(6)
     >>> [ref.getKeyword() for ref in ref6]
     ['Cu', 'Fe']
@@ -408,6 +442,7 @@ But if we remove only one reference analysis from slot number 6:
 And we manually add references, a new slot will be added at the end of the
 worksheet (slot number 8), cause the slot number 6 is already occupied, as well
 as the rest of the slots:
+
     >>> worksheet.get_analyses_at(9)
     []
 

--- a/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
+++ b/bika/lims/tests/doctests/WorksheetApplyTemplate.rst
@@ -268,13 +268,13 @@ Add duplicates using the same source routine analysis, located at slot 4, but
 manually instead of applying the Worksheet Template:
     >>> dups = worksheet.addDuplicateAnalyses(4)
 
-Three duplicate has been added to the worksheet:
+Three duplicate have been added to the worksheet:
     >>> [dup.getKeyword() for dup in dups]
     ['Cu', 'Fe', 'Au']
 
 And these duplicates have been added in the slot number 5, cause this slot is
 where this duplicate fits better in accordance with the layout defined in the
-worksheet template associated to this worksheet template:
+worksheet template associated to this worksheet:
     >>> dup5 = worksheet.get_analyses_at(5)
     >>> [dup.getKeyword() for dup in dup5]
     ['Cu', 'Fe', 'Au']
@@ -379,4 +379,47 @@ Remove all controls from slot 6:
     >>> worksheet.removeAnalysis(ans6[0])
     >>> worksheet.removeAnalysis(ans6[1])
     >>> worksheet.get_analyses_at(6)
+    []
+
+Add a reference analysis, but manually:
+    >>> ref_ans = worksheet.addReferenceAnalyses(control, [Fe.UID(), Cu.UID()])
+    >>> [ref.getKeyword() for ref in ref_ans]
+    ['Cu', 'Fe']
+
+These reference analyses have been added in the slot number 6, cause this slot
+is where these reference analyses fit better in accordance with the layout
+defined in the worksheet template associated to this worksheet:
+    >>> ref6 = worksheet.get_analyses_at(6)
+    >>> [ref.getKeyword() for ref in ref6]
+    ['Cu', 'Fe']
+
+    >>> refs_uids = [ref.UID() for ref in ref_ans]
+    >>> ref6_uids = [ref.UID() for ref in ref6]
+    >>> [ref for ref in ref6_uids if ref not in refs_uids]
+    []
+
+But if we remove only one reference analysis from slot number 6:
+
+    >>> worksheet.removeAnalysis(ref6[0])
+    >>> ref6 = worksheet.get_analyses_at(6)
+    >>> [ref.getKeyword() for ref in ref6]
+    ['Fe']
+
+And we manually add references, a new slot will be added at the end of the
+worksheet (slot number 8), cause the slot number 6 is already occupied, as well
+as the rest of the slots:
+    >>> worksheet.get_analyses_at(9)
+    []
+
+    >>> ref_ans = worksheet.addReferenceAnalyses(control, [Fe.UID(), Cu.UID()])
+    >>> [ref.getKeyword() for ref in ref_ans]
+    ['Cu', 'Fe']
+
+    >>> ref9 = worksheet.get_analyses_at(9)
+    >>> [ref.getKeyword() for ref in ref9]
+    ['Cu', 'Fe']
+
+    >>> refs_uids = [ref.UID() for ref in ref_ans]
+    >>> ref9_uids = [ref.UID() for ref in ref9]
+    >>> [ref for ref in ref9_uids if ref not in refs_uids]
     []


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Applying Worksheet Template to a Worksheet had some inconsistences that have been fixed with this PR, along with the following issues:

Linked issues:
* [#485 When a Worksheet Template is used, slot positions are not applied correctly](https://github.com/senaite/bika.lims/issues/485)
* [#448 Applying a WS template which references a Duplicate raises an Error](https://github.com/senaite/bika.lims/issues/448)

## Current behavior before PR

Inconsistent behavior with duplicates, references, analyses when using Worksheet Templates.

## Desired behavior after PR is merged

Consistent behavior with duplicates, references, analyses when using Worksheet Templates.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
