### PR TITLE
Duplicate analyses transition to "Attachment due" after submit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+#512 Duplicates transition to "Attachment due" after submit
 
 **Security**
 

--- a/bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
+++ b/bika/lims/profiles/default/workflows/bika_duplicateanalysis_workflow/definition.xml
@@ -130,7 +130,7 @@
     </guard>
   </transition>
 
-  <transition transition_id="submit" title="Submit" new_state="attachment_due" trigger="USER" before_script="" after_script="" i18n:attributes="title">
+  <transition transition_id="submit" title="Submit" new_state="to_be_verified" trigger="USER" before_script="" after_script="" i18n:attributes="title">
     <action url="" category="workflow" icon="">Submit for verification</action>
     <guard>
     </guard>

--- a/bika/lims/upgrade/v01_01_009.py
+++ b/bika/lims/upgrade/v01_01_009.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
-from bika.lims import logger
+from bika.lims import logger, api
+from bika.lims.catalog.analysis_catalog import CATALOG_ANALYSIS_LISTING
 from bika.lims.config import PROJECTNAME as product
 from bika.lims.upgrade import upgradestep
 from bika.lims.upgrade.utils import UpgradeUtils
+from Products.CMFCore.Expression import Expression
+from bika.lims.utils import changeWorkflowState
 
 version = '1.1.9'  # Remember version number in metadata.xml and setup.py
 profile = 'profile-{0}:default'.format(product)
@@ -22,7 +25,83 @@ def upgrade(tool):
     logger.info("Upgrading {0}: {1} -> {2}".format(product, ver_from, version))
 
     # -------- ADD YOUR STUFF HERE --------
+    fix_workflow_transitions(portal)
 
     logger.info("{0} upgraded to version {1}".format(product, version))
 
     return True
+
+
+def fix_workflow_transitions(portal):
+    """
+    Replace target states from some workflow statuses
+    """
+    logger.info("Fixing workflow transitions...")
+    tochange = [
+        {'wfid': 'bika_duplicateanalysis_workflow',
+         'trid': 'submit',
+         'changes': {
+             'new_state_id': 'to_be_verified',
+             'guard_expr': ''
+            },
+         'update': {
+             'catalog': CATALOG_ANALYSIS_LISTING,
+             'portal_type': 'DuplicateAnalysis',
+             'status_from': 'attachment_due',
+             'status_to': 'to_be_verified'
+            }
+         }
+    ]
+
+    wtool = api.get_tool('portal_workflow')
+    for item in tochange:
+        wfid = item['wfid']
+        trid = item['trid']
+        workflow = wtool.getWorkflowById(wfid)
+        transitions = workflow.transitions
+        transition = transitions[trid]
+        changes = item.get('changes', {})
+
+        if 'new_state_id' in changes:
+            new_state_id = changes['new_state_id']
+            oldstate = transition.new_state_id
+            logger.info(
+                "Replacing target state '{0}' from '{1}.{2}' to {3}"
+                    .format(oldstate, wfid, trid, new_state_id)
+            )
+            transition.new_state_id = new_state_id
+
+        if 'guard_expr' in changes:
+            new_guard = changes['guard_expr']
+            if not new_guard:
+                transition.guard = None
+                logger.info(
+                    "Removing guard expression from '{0}.{1}'"
+                        .format(wfid, trid))
+            else:
+                guard = transition.getGuard()
+                guard.expr = Expression(new_guard)
+                transition.guard = guard
+                logger.info(
+                    "Replacing guard expression from '{0}.{1}' to {2}"
+                        .format(wfid, trid, new_guard))
+
+        update = item.get('update', {})
+        if update:
+            catalog_id = update['catalog']
+            portal_type = update['portal_type']
+            catalog = api.get_tool(catalog_id)
+            brains = catalog(portal_type=portal_type)
+            for brain in brains:
+                obj = api.get_object(brain)
+                if 'status_from' in update and 'status_to' in update:
+                    status_from = update['status_from']
+                    status_to = update['status_to']
+                    if status_from == brain.review_state:
+                        logger.info(
+                            "Changing status for {0} from '{1} to {2}"
+                                .format(obj.getId(), status_from, status_to))
+                        changeWorkflowState(obj, wfid, status_to)
+
+                workflow.updateRoleMappingsFor(obj)
+                obj.reindexObject()


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Duplicate analyses transition to "Attachment due" on submit

Linked issue: [#481 Duplicates transition to "Attachment due" after submit and can't be transitioned any more](https://github.com/senaite/bika.lims/issues/481)

## Current behavior before PR

Duplicate analyses transition to `attachment_due` on submit and can't be transitioned anymore.

## Desired behavior after PR is merged

Duplicate analyses transition to `to_be_verified` on submit and follow the standard workflow

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
