### PR TITLE
ShowPrices doctest is failing

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #513 ShowPrices doctest is failing
 
 **Security**
 

--- a/bika/lims/tests/doctests/ShowPrices.rst
+++ b/bika/lims/tests/doctests/ShowPrices.rst
@@ -24,6 +24,7 @@ Needed Imports:
     >>> from plone import api as ploneapi
     >>> from plone.app.testing import setRoles
     >>> from plone.app.testing import TEST_USER_ID
+    >>> from time import sleep
     >>> import transaction
 
 Functional Helpers:
@@ -36,10 +37,12 @@ Functional Helpers:
     >>> def enableShowPrices():
     ...     self.portal.bika_setup.setShowPrices(True)
     ...     transaction.commit()
+    ...     sleep(1)
 
     >>> def disableShowPrices():
     ...     self.portal.bika_setup.setShowPrices(False)
     ...     transaction.commit()
+    ...     sleep(1)
 
 Variables:
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Doctest `ShowPrices.rst` fails. Added a delay of 1 second after `transaction.commit()`

Linked issue: [ ShowPrices doctest is failing #463](https://github.com/senaite/bika.lims/issues/463)

## Current behavior before PR

```
$ bin/test -t ShowPrices
Failure in test /home/travis/build/senaite/bika.lims/bika/lims/tests/doctests/ShowPrices.rst
Traceback (most recent call last):
  File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/usr/lib/python2.7/doctest.py", line 2226, in runTest
    raise self.failureException(self.format_failure(new.getvalue()))
AssertionError: Failed doctest test for ShowPrices.rst
  File "/home/travis/build/senaite/bika.lims/bika/lims/tests/doctests/ShowPrices.rst", line 0
----------------------------------------------------------------------
File "/home/travis/build/senaite/bika.lims/bika/lims/tests/doctests/ShowPrices.rst", line 169, in ShowPrices.rst
Failed example:
    True if "409" not in browser.contents else "Accreditation listing should not have Price column, but it is visible."
Differences (ndiff with -expected +actual):
    - True
    + 'Accreditation listing should not have Price column, but it is visible.'
----------------------------------------------------------------------
File "/home/travis/build/senaite/bika.lims/bika/lims/tests/doctests/ShowPrices.rst", line 185, in ShowPrices.rst
Failed example:
    True if "409" not in browser.contents else "Profile Analyses should NOT be showing Price."
Differences (ndiff with -expected +actual):
    - True
    + 'Profile Analyses should NOT be showing Price.'
----------------------------------------------------------------------
File "/home/travis/build/senaite/bika.lims/bika/lims/tests/doctests/ShowPrices.rst", line 201, in ShowPrices.rst
Failed example:
    True if "409"  not in browser.contents else "AR Templates should NOT be showing Price."
Differences (ndiff with -expected +actual):
    - True
    + 'AR Templates should NOT be showing Price.'
```

## Desired behavior after PR is merged

```
$ bin/test -t ShowPrices

Running bika.lims.testing.BikaLIMSLayer:Functional tests:
  Set up plone.testing.zca.LayerCleanup in 0.000 seconds.
  Set up plone.testing.z2.Startup in 0.212 seconds.
  Set up plone.app.testing.layers.PloneFixture in 13.703 seconds.
  Set up bika.lims.testing.BikaLIMSLayer in 15.807 seconds.
  Set up bika.lims.testing.BikaLIMSLayer:Functional in 0.000 seconds.
  Running:
    1/1 (100.0%)/xispa/zinstance/src/bika.lims/bika/lims
                
  Ran 1 tests with 0 failures and 0 errors in 32.571 seconds.

Tearing down left over layers:
  Tear down bika.lims.testing.BikaLIMSLayer:Functional in 0.000 seconds.
  Tear down bika.lims.testing.BikaLIMSLayer in 0.005 seconds.
  Tear down plone.app.testing.layers.PloneFixture in 0.051 seconds.
  Tear down plone.testing.z2.Startup in 0.005 seconds.
  Tear down plone.testing.zca.LayerCleanup in 0.002 seconds.
```

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
