### PR TITLE
Site error when listing Dormant Worksheet Templates

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #514 Site Error when listing Dormant Worksheet Templates
 
 **Security**
 

--- a/bika/lims/controlpanel/bika_worksheettemplates.py
+++ b/bika/lims/controlpanel/bika_worksheettemplates.py
@@ -3,25 +3,18 @@
 # Copyright 2011-2016 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from AccessControl import ClassSecurityInfo
 from Products.ATContentTypes.content import schemata
 from Products.Archetypes import atapi
-from Products.Archetypes.public import *
-from Products.CMFCore import permissions
-from Products.CMFCore.utils import getToolByName
-from bika.lims.browser import BrowserView
+from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t, get_link
-from bika.lims.content.bikaschema import BikaFolderSchema
-from plone.app.layout.globals.interfaces import IViewView
-from ZODB.POSException import ConflictError
+from bika.lims.interfaces import IWorksheetTemplates
+from bika.lims.utils import get_link
 from plone.app.content.browser.interfaces import IFolderContentsView
 from plone.app.folder.folder import ATFolder, ATFolderSchema
-from bika.lims.interfaces import IWorksheetTemplates
+from plone.app.layout.globals.interfaces import IViewView
 from zope.interface.declarations import implements
-import plone, json
+
 
 class WorksheetTemplatesView(BikaListingView):
     implements(IFolderContentsView, IViewView)

--- a/bika/lims/controlpanel/bika_worksheettemplates.py
+++ b/bika/lims/controlpanel/bika_worksheettemplates.py
@@ -13,7 +13,7 @@ from bika.lims.browser import BrowserView
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.config import PROJECTNAME
 from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t
+from bika.lims.utils import t, get_link
 from bika.lims.content.bikaschema import BikaFolderSchema
 from plone.app.layout.globals.interfaces import IViewView
 from ZODB.POSException import ConflictError
@@ -35,12 +35,15 @@ class WorksheetTemplatesView(BikaListingView):
                                 {'url': 'createObject?type_name=WorksheetTemplate',
                                  'icon': '++resource++bika.lims.images/add.png'}}
         self.title = self.context.translate(_("Worksheet Templates"))
-        self.icon = self.portal_url + "/++resource++bika.lims.images/worksheettemplate_big.png"
+        self.form_id = "list_worksheettemplates"
         self.description = ""
         self.show_sort_column = False
         self.show_select_row = False
         self.show_select_column = True
         self.pagesize = 25
+        self.icon = '{}/{}/{}'.format(self.portal_url,
+                                      '++resource++bika.lims.images',
+                                      'worksheettemplate_big.png')
 
         self.columns = {
             'Title': {'title': _('Title'),
@@ -64,7 +67,7 @@ class WorksheetTemplatesView(BikaListingView):
             {'id':'inactive',
              'title': _('Dormant'),
              'contentFilter': {'inactive_state': 'inactive'},
-             'transitions': ['activate', ],
+             'transitions': [{'id': 'activate'}, ],
              'columns': ['Title',
                          'Description',
                          'Instrument']},
@@ -76,16 +79,14 @@ class WorksheetTemplatesView(BikaListingView):
                          'Instrument']},
         ]
 
-    def folderitems(self):
-        items = BikaListingView.folderitems(self)
-        for x in range(len(items)):
-            if not items[x].has_key('obj'): continue
-            obj = items[x]['obj']
-            items[x]['Description'] = obj.Description()
-            items[x]['Instrument'] = obj.getInstrument() and obj.getInstrument().Title() or ' '
-            items[x]['replace']['Title'] = "<a href='%s'>%s</a>" % \
-                 (items[x]['url'], items[x]['Title'])
-        return items
+    def folderitem(self, obj, item, index):
+        item['Description'] = obj.Description()
+        item['replace']['Title'] = get_link(item['url'], item['Title'])
+        item['Instrument'] = ''
+        instrument = obj.getInstrument()
+        item['Instrument'] = instrument and instrument.getTitle() or ''
+        return item
+
 
 schema = ATFolderSchema.copy()
 class WorksheetTemplates(ATFolder):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: [ Site Error listing Dormant WS Templates #511](https://github.com/senaite/bika.lims/issues/511)

## Current behavior before PR

The following error occurs when user filters the list of Worksheet Templates by "Dormant" state:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.bika_listing, line 939, in __call__
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 171, in render
  Module dcf338d4245d77cfcfc04453ac6e7b85.py, line 425, in render
  Module 88494a7718bbc1a5b87718fc8292f294.py, line 1406, in render_master
  Module 88494a7718bbc1a5b87718fc8292f294.py, line 571, in render_content
  Module dcf338d4245d77cfcfc04453ac6e7b85.py, line 355, in __fill_content_core
  Module five.pt.expressions, line 161, in __call__
  Module bika.lims.browser.bika_listing, line 1380, in contents_table
  Module Products.Five.browser.pagetemplatefile, line 125, in __call__
  Module Products.Five.browser.pagetemplatefile, line 59, in __call__
  Module zope.pagetemplate.pagetemplate, line 132, in pt_render
  Module five.pt.engine, line 98, in __call__
  Module z3c.pt.pagetemplate, line 163, in render
  Module chameleon.zpt.template, line 289, in render
  Module chameleon.template, line 191, in render
  Module chameleon.template, line 171, in render
  Module 63467377297b85be02085ad2c879e96e.py, line 1796, in render
TypeError: string indices must be integers, not str

 - Expression: "here/main_template/macros/master"
 - Filename:   ... rc/bika.lims/bika/lims/browser/templates/bika_listing.pt
 - Location:   (line 5: col 21)
 - Source:     metal:use-macro="here/main_template/macros/master"
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Expression: "python:','.join([trans['id'] for trans in view.bika_listing.review_state.get('transitions', [])])"
 - Filename:   ... a.lims/bika/lims/browser/templates/bika_listing_table.pt
 - Location:   (line 271: col 38)
 - Source:     ... python:','.join([trans['id'] for trans in view.bika_listing.review_state.get('transitions', [])]) ...
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 - Arguments:  rows_only: False
               request: <instance - at 0x7f218cbdfb48>
               table_only: False
               ViewResults: 1
               EditAnalyses: 1
               toggle_cols: {...} (3)
               container: <ImplicitAcquisitionWrapper bika_worksheettemplates at 0x7f2189024aa0>
               specification: <NoneType - at 0x8fe4d0>
               wrapped_repeat: <SafeMapping - at 0x7f218b160ec0>
               traverse_subpath: <list - at 0x7f2189e45b90>
               column_list: <list - at 0x7f218e36a998>
               template: <ViewPageTemplateFile - at 0x7f2195bf8e10>
               nosortclass: nosort
               review_state: {...} (5)
               translate: <function translate at 0x7f218955b230>
               columns: {...} (3)
               klass: sortable column 
               tabindex: <generator tabindex at 0x7f218955ec30>
               repeat: {...} (0)
               form_id: list
               views: <ViewMapper - at 0x7f21892d1450>
               args: <tuple - at 0x7f21893da690>
               here: <ImplicitAcquisitionWrapper bika_worksheettemplates at 0x7f2189024aa0>
               portal: <ImplicitAcquisitionWrapper senaite at 0x7f2188fc9870>
               user: <ImplicitAcquisitionWrapper - at 0x7f2189024af0>
               nothing: <NoneType - at 0x8fe4d0>
               target_language: <NoneType - at 0x8fe4d0>
               context: <ImplicitAcquisitionWrapper bika_worksheettemplates at 0x7f2189024aa0>
               nr_cols: 4
               roles: <list - at 0x7f2189bab710>
               default: <object - at 0x7f21bdf92560>
               modules: <instance - at 0x7f21b6494ef0>
               col: Title
               review_state_id: inactive
               t: {...} (4)
               sm: <SecurityManager - at 0x7f218925cc08>
               trans: activate
               root: <ImplicitAcquisitionWrapper Zope at 0x7f2188febcd0>
               options: {...} (0)
               loop: {...} (3)
               view: <BikaListingTable - at 0x7f21892d1790>
```


## Desired behavior after PR is merged

No error is rised and the Dormant Worksheet Templates are listed correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
