### PR TITLE
Do not display expired or dormant Reference Samples in Add Blank/Add Control views

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changelog
 
 **Fixed**
 
+- #517 Expired Reference Samples are displayed in Add Blank/Add Control views
+- #517 Inactive services displayed for selection in Add Blank/Add Control views
 
 **Security**
 

--- a/bika/lims/browser/worksheet/views/referencesamples.py
+++ b/bika/lims/browser/worksheet/views/referencesamples.py
@@ -6,6 +6,8 @@
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 from operator import itemgetter
+
+from bika.lims.workflow import isActive
 from plone.app.layout.globals.interfaces import IViewView
 from Products.CMFCore.utils import getToolByName
 from zope.interface import implements
@@ -42,7 +44,7 @@ class ReferenceSamplesView(BaseView):
         self.review_states = [
             {'id':'default',
              'title': _('All'),
-             'contentFilter':{'review_state':'current'},
+             'contentFilter':{'review_state': 'current'},
              'columns': ['ID',
                          'Title',
                          'Definition',
@@ -57,6 +59,14 @@ class ReferenceSamplesView(BaseView):
         if not self.control_type:
             return t(_("No control type specified"))
         return super(ReferenceSamplesView, self).contents_table()
+
+    def isItemAllowed(self, obj):
+        """
+        Only valid reference samples (neither expired nor disposed) are allowed
+        """
+        if not obj.isValid() or not isActive(obj):
+            return False
+        return super(ReferenceSamplesView, self).isItemAllowed(obj)
 
     def folderitems(self):
         translate = self.context.translate

--- a/bika/lims/browser/worksheet/views/services.py
+++ b/bika/lims/browser/worksheet/views/services.py
@@ -38,7 +38,7 @@ class ServicesView(BikaListingView):
         self.review_states = [
             {'id':'default',
              'title': _('All'),
-             'contentFilter': {},
+             'contentFilter': {'inactive_state': 'active'},
              'transitions': [],
              'columns':['Service'],
             },

--- a/bika/lims/content/referencesample.py
+++ b/bika/lims/content/referencesample.py
@@ -393,6 +393,26 @@ class ReferenceSample(BaseFolder):
                     specstr = specs[0]
         return specstr
 
+    def isValid(self):
+        """
+        Returns if the current Reference Sample is valid. This is, the sample
+        hasn't neither been expired nor disposed.
+        """
+        today = DateTime()
+        expiry_date = self.getExpiryDate()
+        if expiry_date and today > expiry_date:
+            return False
+        # TODO: Do We really need ExpiryDate + DateExpired? Any difference?
+        date_expired = self.getDateExpired()
+        if date_expired and today > date_expired:
+            return False
+
+        date_disposed = self.getDateDisposed()
+        if date_disposed and today > date_disposed:
+            return False
+
+        return True
+
     # XXX workflow methods
     def workflow_script_expire(self):
         """ expire sample """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Expired/Dormant Reference Samples was displayed in Add Blank/Add Control views because there was no filtering by expiry date neither by `inactive_state=active`. Nevertheless, refsamples use their own workflow with their own states that make the whole thing confusing (by default, `review_state==current`).

Also, inactive services were displayed for selection (on the right) in the same views as before. Again, the reason was that there was no filtering by `inactive_state=active`.

Linked issue: [Dormant Reference Samples are listed for selection on WSs. And can be assigned #504](https://github.com/senaite/bika.lims/issues/504)

## Current behavior before PR

Expired and dormant reference samples are listed for selection in Add Blank and Add Control views from Worksheet.

Inactive Analysis Services appear for selection in Add Blank and Add Control views from worksheet.

## Desired behavior after PR is merged

Expired and dormant reference samples are not listed for selection in Add Blank and Add Control views from Worksheet.

Inactive Analysis Services do not appear for selection in Add Blank and Add Control views from worksheet.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
