### PR TITLE
Fix analyses listing does not show attached Analyses in Worksheets

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Changelog
 
 **Fixed**
 
+- #522 Worksheets: Analyses listing does not show attached Analyses
 - #514 Site Error when listing Dormant Worksheet Templates
 - #517 Expired Reference Samples are displayed in Add Blank/Add Control views
 - #517 Inactive services displayed for selection in Add Blank/Add Control views

--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -635,6 +635,8 @@ class AnalysesView(BikaListingView):
                 for attachment in attachments_objs:
                     af = attachment.getAttachmentFile()
                     icon = af.icon
+                    if callable(icon):
+                        icon = icon()
                     attachments += \
                         "<span class='attachment' attachment_uid='%s'>" % \
                         (attachment.UID())

--- a/bika/lims/browser/js/bika.lims.utils.attachments.js
+++ b/bika/lims/browser/js/bika.lims.utils.attachments.js
@@ -1,70 +1,96 @@
+
+/* Please use this command to compile this file into the parent `js` directory:
+    coffee --no-header -w -o ../ -c bika.lims.utils.attachments.coffee
+ */
+
+
 /**
  * Controller class for calculation events
  */
-function AttachmentsUtils() {
 
-    var that = this;
-
+(function() {
+  window.AttachmentsUtils = function() {
+    var that;
+    that = this;
     that.load = function() {
-
-        // Worksheets need to check these before enabling Add button
-        $("#AttachFile,#Service,#Analysis").change(function(event){
-            attachfile = $("#AttachFile").val();
-            if(attachfile == undefined){attachfile = '';}
-            service = $("#Service").val();
-            if(service == undefined){service = '';}
-            analysis = $("#Analysis").val();
-            if(analysis == undefined){analysis= '';}
-
-            if (this.id == 'Service') {
-                $("#Analysis").val('');
+      $('#AttachFile,#Service,#Analysis').change(function(event) {
+        var analysis, attachfile, service;
+        attachfile = $('#AttachFile').val();
+        if (attachfile === void 0) {
+          attachfile = '';
+        }
+        service = $('#Service').val();
+        if (service === void 0) {
+          service = '';
+        }
+        analysis = $('#Analysis').val();
+        if (analysis === void 0) {
+          analysis = '';
+        }
+        if (this.id === 'Service') {
+          $('#Analysis').val('');
+        }
+        if (this.id === 'Analysis') {
+          $('#Service').val('');
+        }
+        if (attachfile !== '' && (service !== '' || analysis !== '')) {
+          $('#addButton').removeAttr('disabled');
+        } else {
+          $('#addButton').prop('disabled', true);
+        }
+      });
+      $('.deleteAttachmentButton').live('click', function() {
+        var attachment_uid, options;
+        attachment_uid = $(this).attr('attachment_uid');
+        options = {
+          url: '@@ajax_attachments_view/delete_analysis_attachment',
+          type: 'POST',
+          success: function(responseText, statusText, xhr, $form) {
+            if (responseText === 'success') {
+              $("span[attachment_uid=" + attachment_uid + "]").remove();
             }
-            if (this.id == 'Analysis') {
-                $("#Service").val('');
-            }
+          },
+          data: {
+            'attachment_uid': attachment_uid,
+            '_authenticator': $('input[name="_authenticator"]').val()
+          }
+        };
+        $.ajax(options);
+      });
+      $('#Analysis').combogrid({
+        colModel: [
+          {
+            'columnName': 'analysis_uid',
+            'hidden': true
+          }, {
+            'columnName': 'slot',
+            'width': '10',
+            'label': _('Slot')
+          }, {
+            'columnName': 'service',
+            'width': '35',
+            'label': _('Service')
+          }, {
+            'columnName': 'parent',
+            'width': '35',
+            'label': _('Parent')
+          }, {
+            'columnName': 'type',
+            'width': '20',
+            'label': _('Type')
+          }
+        ],
+        url: window.location.href.replace('/manage_results', '') + '/attachAnalyses?_authenticator=' + $('input[name="_authenticator"]').val(),
+        showOn: true,
+        width: '650px',
+        select: function(event, ui) {
+          $('#Analysis').val(ui.item.service + (" (slot " + ui.item.slot + ")"));
+          $('#analysis_uid').val(ui.item.analysis_uid);
+          $(this).change();
+          return false;
+        }
+      });
+    };
+  };
 
-            if (attachfile != '' && ((service != '') || (analysis != ''))) {
-                $("#addButton").removeAttr("disabled");
-            } else {
-                $("#addButton").prop("disabled", true);
-            }
-        });
-
-        // This is the button next to analysis attachments in ARs and Worksheets
-        $('.deleteAttachmentButton').live("click", function(){
-            attachment_uid = $(this).attr("attachment_uid");
-            options = {
-                url: 'delete_analysis_attachment',
-                type: 'POST',
-                success: function(responseText, statusText, xhr, $form) {
-                    if(responseText == "success"){
-                        $("span[attachment_uid='"+attachment_uid+"']").remove();
-                    }
-                },
-                data: {
-                    'attachment_uid': attachment_uid,
-                    '_authenticator': $('input[name="_authenticator"]').val()
-                },
-            }
-            $.ajax(options);
-        });
-
-        // Dropdown grid of Analyses in attachment forms
-        $("#Analysis" ).combogrid({
-            colModel: [{'columnName':'analysis_uid','hidden':true},
-                       {'columnName':'slot','width':'10','label':_('Slot')},
-                       {'columnName':'service','width':'35','label':_('Service')},
-                       {'columnName':'parent','width':'35','label':_('Parent')},
-                       {'columnName':'type','width':'20','label':_('Type')}],
-            url: window.location.href.replace("/manage_results","") + "/attachAnalyses?_authenticator=" + $('input[name="_authenticator"]').val(),
-            showOn: true,
-            width: '650px',
-            select: function( event, ui ) {
-                $( "#Analysis" ).val(ui.item.service + " (slot "+ui.item.slot+")");
-                $( "#analysis_uid" ).val(ui.item.analysis_uid);
-                $(this).change();
-                return false;
-            }
-        });
-    }
-}
+}).call(this);

--- a/bika/lims/browser/js/coffee/bika.lims.utils.attachments.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.utils.attachments.coffee
@@ -1,0 +1,89 @@
+### Please use this command to compile this file into the parent `js` directory:
+    coffee --no-header -w -o ../ -c bika.lims.utils.attachments.coffee
+###
+
+###*
+# Controller class for calculation events
+###
+
+window.AttachmentsUtils = ->
+  that = this
+
+  that.load = ->
+    # Worksheets need to check these before enabling Add button
+    $('#AttachFile,#Service,#Analysis').change (event) ->
+      attachfile = $('#AttachFile').val()
+      if attachfile == undefined
+        attachfile = ''
+      service = $('#Service').val()
+      if service == undefined
+        service = ''
+      analysis = $('#Analysis').val()
+      if analysis == undefined
+        analysis = ''
+      if @id == 'Service'
+        $('#Analysis').val ''
+      if @id == 'Analysis'
+        $('#Service').val ''
+      if attachfile != '' and (service != '' or analysis != '')
+        $('#addButton').removeAttr 'disabled'
+      else
+        $('#addButton').prop 'disabled', true
+      return
+
+    # This is the button next to analysis attachments in ARs and Worksheets
+    $('.deleteAttachmentButton').live 'click', ->
+      attachment_uid = $(this).attr('attachment_uid')
+      options =
+        url: '@@ajax_attachments_view/delete_analysis_attachment'
+        type: 'POST'
+        success: (responseText, statusText, xhr, $form) ->
+          if responseText == 'success'
+            $("span[attachment_uid=#{attachment_uid}]").remove()
+          return
+        data:
+          'attachment_uid': attachment_uid
+          '_authenticator': $('input[name="_authenticator"]').val()
+      $.ajax options
+      return
+
+    # Dropdown grid of Analyses in attachment forms
+    $('#Analysis').combogrid
+      colModel: [
+        {
+          'columnName': 'analysis_uid'
+          'hidden': true
+        }
+        {
+          'columnName': 'slot'
+          'width': '10'
+          'label': _('Slot')
+        }
+        {
+          'columnName': 'service'
+          'width': '35'
+          'label': _('Service')
+        }
+        {
+          'columnName': 'parent'
+          'width': '35'
+          'label': _('Parent')
+        }
+        {
+          'columnName': 'type'
+          'width': '20'
+          'label': _('Type')
+        }
+      ]
+      url: window.location.href.replace('/manage_results', '') + '/attachAnalyses?_authenticator=' + $('input[name="_authenticator"]').val()
+      showOn: true
+      width: '650px'
+      select: (event, ui) ->
+        $('#Analysis').val ui.item.service + " (slot #{ui.item.slot})"
+        $('#analysis_uid').val ui.item.analysis_uid
+        $(this).change()
+        false
+
+    return
+
+  return

--- a/bika/lims/browser/viewlets/templates/worksheet_attachments.pt
+++ b/bika/lims/browser/viewlets/templates/worksheet_attachments.pt
@@ -15,7 +15,17 @@
 
       <!-- Add Attachments -->
       <div class="ws_attachments_add">
-        <form action="." method="post" name="add_attachment" enctype="multipart/form-data">
+
+        <!-- Add Form -->
+        <form action="attachments_view"
+              name="attachments_add_form"
+              enctype="multipart/form-data"
+              tal:attributes="action string:${context/absolute_url}/@@attachments_view/add_to_ws"
+              method="POST">
+
+          <input type="hidden" name="submitted" value="1"/>
+          <span tal:replace="structure context/@@authenticator/authenticator"/>
+
           <table class="listing">
             <tr>
               <th i18n:translate="">Add new Attachment</th>

--- a/bika/lims/browser/worksheet/views/results.py
+++ b/bika/lims/browser/worksheet/views/results.py
@@ -2,41 +2,39 @@
 
 # This file is part of Bika LIMS
 #
-# Copyright 2011-2016 by it's authors.
+# Copyright 2011-2017 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
+from bika.lims import bikaMessageFactory as _
+from bika.lims.browser import BrowserView
+from bika.lims.browser.worksheet.tools import (checkUserAccess,
+                                               showRejectionMessage)
+from bika.lims.browser.worksheet.views import (AnalysesTransposedView,
+                                               AnalysesView)
+from bika.lims.config import WORKSHEET_LAYOUT_OPTIONS
+from bika.lims.utils import getUsers, tmpID
 from plone.app.layout.globals.interfaces import IViewView
 from Products.Archetypes.config import REFERENCE_CATALOG
 from Products.Archetypes.public import DisplayList
-from Products.CMFPlone.i18nl10n import ulocalized_time
-from Products.CMFPlone.utils import _createObjectByType
-from Products.CMFPlone.utils import safe_unicode
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType, safe_unicode
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 from zope.interface import implements
-
-from bika.lims import bikaMessageFactory as _
-from bika.lims.config import WORKSHEET_LAYOUT_OPTIONS
-from bika.lims.utils import t
-from bika.lims.browser import BrowserView
-from bika.lims.browser.worksheet.tools import checkUserAccess
-from bika.lims.browser.worksheet.tools import showRejectionMessage
-from bika.lims.browser.worksheet.views import AnalysesTransposedView
-from bika.lims.browser.worksheet.views import AnalysesView
-from bika.lims.utils import getUsers, tmpID
 
 
 class ManageResultsView(BrowserView):
     implements(IViewView)
     template = ViewPageTemplateFile("../templates/results.pt")
+
     def __init__(self, context, request):
         BrowserView.__init__(self, context, request)
         self.getAnalysts = getUsers(context, ['Manager', 'LabManager', 'Analyst'])
         self.layout_displaylist = WORKSHEET_LAYOUT_OPTIONS
 
     def __call__(self):
+
         # Deny access to foreign analysts
-        if checkUserAccess(self.context, self.request) == False:
+        if checkUserAccess(self.context, self.request) is False:
             return []
 
         showRejectionMessage(self.context)
@@ -46,7 +44,7 @@ class ManageResultsView(BrowserView):
         # Worksheet Attachmemts
         # the expandable form is handled here.
         if "AttachmentFile_file" in self.request:
-            this_file =  self.request['AttachmentFile_file']
+            this_file = self.request['AttachmentFile_file']
             if 'analysis_uid' in self.request:
                 analysis_uid = self.request['analysis_uid']
             else:
@@ -82,14 +80,14 @@ class ManageResultsView(BrowserView):
                     if not analysis.getServiceUID() == service_uid:
                         continue
                     review_state = workflow.getInfoFor(analysis, 'review_state', '')
-                    if not review_state in ['assigned', 'sample_received', 'to_be_verified']:
+                    if review_state not in ['assigned', 'sample_received', 'to_be_verified']:
                         continue
 
                     attachment = _createObjectByType("Attachment", ws, tmpID())
                     attachment.edit(
-                        AttachmentFile = this_file,
-                        AttachmentType = self.request.get('AttachmentType', ''),
-                        AttachmentKeys = self.request['AttachmentKeys'])
+                        AttachmentFile=this_file,
+                        AttachmentType=self.request.get('AttachmentType', ''),
+                        AttachmentKeys=self.request['AttachmentKeys'])
                     attachment.processForm()
                     attachment.reindexObject()
 
@@ -103,7 +101,7 @@ class ManageResultsView(BrowserView):
         # Save the results layout
         rlayout = self.request.get('resultslayout', '')
         if rlayout and rlayout in WORKSHEET_LAYOUT_OPTIONS.keys() \
-            and rlayout != self.context.getResultsLayout():
+           and rlayout != self.context.getResultsLayout():
             self.context.setResultsLayout(rlayout)
             message = _("Changes saved.")
             self.context.plone_utils.addPortalMessage(message, 'info')
@@ -128,8 +126,8 @@ class ManageResultsView(BrowserView):
         # TODO: Return only the allowed instruments for at least one contained analysis
         bsc = getToolByName(self, 'bika_setup_catalog')
         items = [('', '')] + [(o.UID, o.Title) for o in
-                               bsc(portal_type = 'Instrument',
-                                   inactive_state = 'active')]
+                              bsc(portal_type='Instrument',
+                                  inactive_state='active')]
         o = self.context.getInstrument()
         if o and o.UID() not in [i[0] for i in items]:
             items.append((o.UID(), o.Title()))
@@ -186,7 +184,7 @@ class ManageResultsView(BrowserView):
             # Interims from calculation
             for field in calculation.getInterimFields():
                 if field['keyword'] not in andict['interims'].keys() \
-                    and field.get('wide', False):
+                   and field.get('wide', False):
                     andict['interims'][field['keyword']] = field
 
             if andict['interims']:

--- a/bika/lims/browser/worksheet/views/results.py
+++ b/bika/lims/browser/worksheet/views/results.py
@@ -47,15 +47,9 @@ class ManageResultsView(BrowserView):
         #       accordingly!
         #       Relevant issue: https://github.com/senaite/bika.lims/issues/521
         if "AttachmentFile_file" in self.request:
-            this_file = self.request['AttachmentFile_file']
-            if 'analysis_uid' in self.request:
-                analysis_uid = self.request['analysis_uid']
-            else:
-                analysis_uid = None
-            if 'Service' in self.request:
-                service_uid = self.request['Service']
-            else:
-                service_uid = None
+            this_file = self.request.get('AttachmentFile_file', None)
+            analysis_uid = self.request.get('analysis_uid', None)
+            service_uid = self.request.get('Service', None)
 
             ws = self.context
             tool = getToolByName(self.context, REFERENCE_CATALOG)

--- a/bika/lims/browser/worksheet/views/results.py
+++ b/bika/lims/browser/worksheet/views/results.py
@@ -99,6 +99,11 @@ class ManageResultsView(BrowserView):
                         attachments.append(other.UID())
                     attachments.append(attachment.UID())
                     analysis.setAttachment(attachments)
+
+                    # The metadata for getAttachmentUIDs need to get updated,
+                    # otherwise the attachments are not displayed
+                    # https://github.com/senaite/bika.lims/issues/521
+                    analysis.reindexObject()
         # /TODO
 
         # Save the results layout

--- a/bika/lims/browser/worksheet/views/results.py
+++ b/bika/lims/browser/worksheet/views/results.py
@@ -41,8 +41,11 @@ class ManageResultsView(BrowserView):
 
         self.icon = self.portal_url + "/++resource++bika.lims.images/worksheet_big.png"
 
-        # Worksheet Attachmemts
-        # the expandable form is handled here.
+        # TODO: Move this form handler into bika.lims.browser.attachment and
+        #       change the form action of
+        #       bika.lims.browser.viewlets.templates.worksheet_attachments.pt
+        #       accordingly!
+        #       Relevant issue: https://github.com/senaite/bika.lims/issues/521
         if "AttachmentFile_file" in self.request:
             this_file = self.request['AttachmentFile_file']
             if 'analysis_uid' in self.request:
@@ -72,6 +75,11 @@ class ManageResultsView(BrowserView):
                 attachments.append(attachment.UID())
                 analysis.setAttachment(attachments)
 
+                # The metadata for getAttachmentUIDs need to get updated,
+                # otherwise the attachments are not displayed
+                # https://github.com/senaite/bika.lims/issues/521
+                analysis.reindexObject()
+
             if service_uid:
                 workflow = getToolByName(self.context, 'portal_workflow')
                 for analysis in self._getAnalyses():
@@ -97,6 +105,7 @@ class ManageResultsView(BrowserView):
                         attachments.append(other.UID())
                     attachments.append(attachment.UID())
                     analysis.setAttachment(attachments)
+        # /TODO
 
         # Save the results layout
         rlayout = self.request.get('resultslayout', '')


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/bika.lims/issues/521

## Current behavior before PR

Attachments of WS Analyses are not displayed

## Desired behavior after PR is merged

Attachments of WS Analyses are displayed correctly and can be deleted

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
